### PR TITLE
複数の SKK 辞書へ対応し，辞書を変更できるようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -476,7 +476,22 @@
         "when": "editorTextFocus",
         "key": "backspace"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "properties": {
+        "skk.dictUrls": {
+          "type": "array",
+          "items": "string",
+          "default": [
+            "http://openlab.jp/skk/skk/dic/SKK-JISYO.L",
+            "http://openlab.jp/skk/skk/dic/SKK-JISYO.zipcode",
+            "http://openlab.jp/skk/skk/dic/SKK-JISYO.fullname"
+          ],
+          "description": "List of SKK dictionary URLs to load"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
ユーザが任意の辞書を使えるように， settings.json の項目を追加した．
設定では URL の配列を指定し、辞書の検索は配列の中で指定された順序で行なわれる．

closes #27, closes #28