### PR TITLE
SKK Abbrev モードを実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -387,6 +387,12 @@
         "args": ","
       },
       {
+        "command": "skk.symbolInput",
+        "when": "editorTextFocus",
+        "key": "/",
+        "args": "/"
+      },
+      {
         "command": "skk.numberInput",
         "when": "editorTextFocus",
         "key": "0",
@@ -484,9 +490,9 @@
           "type": "array",
           "items": "string",
           "default": [
-            "http://openlab.jp/skk/skk/dic/SKK-JISYO.L",
-            "http://openlab.jp/skk/skk/dic/SKK-JISYO.zipcode",
-            "http://openlab.jp/skk/skk/dic/SKK-JISYO.fullname"
+            "https://github.com/skk-dev/dict/raw/refs/heads/master/SKK-JISYO.L",
+            "https://github.com/skk-dev/dict/raw/refs/heads/master/zipcode/SKK-JISYO.zipcode",
+            "https://github.com/skk-dev/dict/raw/refs/heads/master/SKK-JISYO.fullname"
           ],
           "description": "List of SKK dictionary URLs to load"
         }

--- a/src/input-mode/henkan/AbbrevMode.ts
+++ b/src/input-mode/henkan/AbbrevMode.ts
@@ -1,0 +1,102 @@
+import { DeleteLeftResult, IEditor } from "../../editor/IEditor";
+import { insertOrReplaceSelection } from "../../extension";
+import { Entry } from "../../jisyo/entry";
+import { getGlobalJisyo } from "../../jisyo/jisyo";
+import { AbstractKanaMode } from "../AbstractKanaMode";
+import { AbstractMidashigoMode } from "./AbstractMidashigoMode";
+import { InlineHenkanMode } from "./InlineHenkanMode";
+import { KakuteiMode } from "./KakuteiMode";
+
+
+export class AbbrevMode extends AbstractMidashigoMode {
+    constructor(context: AbstractKanaMode, editor: IEditor) {
+        super("▽", editor);
+
+        const insertStr = "▽";
+        this.editor.setMidashigoStartToCurrentPosition();
+        context.insertStringAndShowRemaining(insertStr, "", false);
+    }
+
+    private findCandidates(midashigo: string): Entry | Error {
+        const candidates = getGlobalJisyo().get(midashigo);
+        if (candidates === undefined) {
+            return new Error('変換できません');
+        } else {
+            return new Entry(midashigo, candidates, "");
+        }
+    }
+
+    private henkan(context: AbstractKanaMode, optionalSuffix?: string): void {
+        const midashigo = this.editor.extractMidashigo();
+        if (!midashigo || midashigo.length === 0) {
+            context.setHenkanMode(KakuteiMode.create(context, this.editor));
+            return;
+        }
+
+        const jisyoEntry = this.findCandidates(midashigo);
+        if (jisyoEntry instanceof Error) {
+            context.showErrorMessage(jisyoEntry.message);
+            return;
+        }
+
+        context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, jisyoEntry, optionalSuffix));
+    }
+
+    onLowerAlphabet(context: AbstractKanaMode, key: string): void {
+        insertOrReplaceSelection(key).then((value) => {
+            this.editor.showRemainingRomaji("", false, 0);
+        });
+    }
+
+    onUpperAlphabet(context: AbstractKanaMode, key: string): void {
+        insertOrReplaceSelection(key).then((value) => {
+            this.editor.showRemainingRomaji("", false, 0);
+        });
+    }
+
+    onNumber(context: AbstractKanaMode, key: string): void {
+        insertOrReplaceSelection(key).then((value) => {
+            this.editor.showRemainingRomaji("", false, 0);
+        });
+    }
+
+    onSymbol(context: AbstractKanaMode, key: string): void {
+        insertOrReplaceSelection(key).then((value) => {
+            this.editor.showRemainingRomaji("", false, 0);
+        });
+    }
+
+    onSpace(context: AbstractKanaMode): void {
+        this.henkan(context, "");
+    }
+
+    onEnter(context: AbstractKanaMode): void {
+        throw new Error("Method not implemented.");
+    }
+
+    onBackspace(context: AbstractKanaMode): void {
+        switch (this.editor.deleteLeft()) {
+            case DeleteLeftResult.markerDeleted:
+            case DeleteLeftResult.markerNotFoundAndOtherCharacterDeleted:
+                context.setHenkanMode(KakuteiMode.create(context, this.editor));
+                break;
+            case DeleteLeftResult.otherCharacterDeleted:
+                // do nothing
+                break;
+            case DeleteLeftResult.noEditor:
+                // error
+                break;
+        }
+    }
+
+    onCtrlJ(context: AbstractKanaMode): void {
+        // delete heading ▽ and fix the remaining text
+        this.editor.fixateMidashigo();
+        context.setHenkanMode(KakuteiMode.create(context, this.editor));
+    }
+
+    onCtrlG(context: AbstractKanaMode): void {
+        context.setHenkanMode(KakuteiMode.create(context, this.editor));
+        this.editor.clearMidashigo();
+    }
+}

--- a/src/input-mode/henkan/AbstractMidashigoMode.ts
+++ b/src/input-mode/henkan/AbstractMidashigoMode.ts
@@ -1,0 +1,4 @@
+import { AbstractHenkanMode } from "./AbstractHenkanMode";
+
+export abstract class AbstractMidashigoMode extends AbstractHenkanMode {
+}

--- a/src/input-mode/henkan/InlineHenkanMode.ts
+++ b/src/input-mode/henkan/InlineHenkanMode.ts
@@ -8,16 +8,16 @@ import { ZeneiMode } from "../ZeneiMode";
 import { AbstractHenkanMode } from "./AbstractHenkanMode";
 import { KakuteiMode } from "./KakuteiMode";
 import { MenuHenkanMode } from "./MenuHenkanMode";
-import { MidashigoMode } from "./MidashigoMode";
+import { AbstractMidashigoMode } from "./AbstractMidashigoMode";
 
 export class InlineHenkanMode extends AbstractHenkanMode {
-    private prevMode: MidashigoMode;
+    private prevMode: AbstractMidashigoMode;
     private origMidashigo: string;
     private jisyoEntry: Entry;
     private candidateIndex: number = 0;
     private readonly suffix: string;
 
-    constructor(context: AbstractKanaMode, editor: IEditor, prevMode: MidashigoMode, origMidashigo: string, jisyoEntry: Entry, optionalSuffix?: string) {
+    constructor(context: AbstractKanaMode, editor: IEditor, prevMode: AbstractMidashigoMode, origMidashigo: string, jisyoEntry: Entry, optionalSuffix?: string) {
         super("▼", editor);
         this.prevMode = prevMode;
         this.origMidashigo = origMidashigo;

--- a/src/input-mode/henkan/KakuteiMode.ts
+++ b/src/input-mode/henkan/KakuteiMode.ts
@@ -1,13 +1,13 @@
 import * as vscode from 'vscode';
-import { AbstractKanaMode } from "../AbstractKanaMode";
-import { AbstractHenkanMode } from "./AbstractHenkanMode";
+import { AbstractKanaMode } from '../AbstractKanaMode';
+import { AbstractHenkanMode } from './AbstractHenkanMode';
 import { RomajiInput } from '../../RomajiInput';
 import { MidashigoMode } from './MidashigoMode';
+import { AbbrevMode } from './AbbrevMode';
 import { setInputMode } from '../../extension';
 import { AsciiMode } from '../AsciiMode';
 import { ZeneiMode } from '../ZeneiMode';
 import { IEditor } from '../../editor/IEditor';
-
 
 export class KakuteiMode extends AbstractHenkanMode {
     romajiInput: RomajiInput;
@@ -54,16 +54,21 @@ export class KakuteiMode extends AbstractHenkanMode {
         let remaining = this.romajiInput.getRemainingRomaji();
 
         // 変換できる文字があればそれを挿入する(例: "n" -> "ん")
-        if (kana.length > 0) {
-            context.insertStringAndShowRemaining(kana, remaining, false);
-            return;
-        }
+        context.insertStringAndShowRemaining(kana, remaining, false).then(() => {
+            // 「/」が入力された場合は SKK Abbrev mode に移行する
+            if (key === "/") {
+                // "/" 自体は挿入しない
+                this.romajiInput.reset();
+                context.setHenkanMode(new AbbrevMode(context, this.editor));
+                return;
+            }
 
-        // TODO: @ が単体で入力された場合などの特殊な処理を記述する
+            // TODO: @ が単体で入力された場合などの特殊な処理を記述する
 
-        // 変換できない場合は， remaining に入っている記号をそのまま挿入
-        this.romajiInput.reset();
-        context.insertStringAndShowRemaining(remaining, "", false);
+            // 変換できない場合は， remaining に入っている記号をそのまま挿入
+            this.romajiInput.reset();
+            context.insertStringAndShowRemaining(remaining, "", false);
+        });
     }
 
     onSpace(context: AbstractKanaMode): void {

--- a/src/input-mode/henkan/MidashigoMode.ts
+++ b/src/input-mode/henkan/MidashigoMode.ts
@@ -24,10 +24,7 @@ export class MidashigoMode extends AbstractMidashigoMode {
         this.romajiInput = context.newRomajiInput();
 
         if (initialRomajiInput) {
-            let insertStr = "▽";
-            this.editor.setMidashigoStartToCurrentPosition();
-
-            insertStr += this.romajiInput.processInput(initialRomajiInput.toLowerCase());
+            const insertStr = "▽" + this.romajiInput.processInput(initialRomajiInput.toLowerCase());
             this.editor.setMidashigoStartToCurrentPosition();
             context.insertStringAndShowRemaining(insertStr, this.romajiInput.getRemainingRomaji(), false);
         }
@@ -46,13 +43,13 @@ export class MidashigoMode extends AbstractMidashigoMode {
     }
 
     private henkan(context: AbstractKanaMode, okuri: string, optionalSuffix?: string): void {
-        let midashigo = this.editor.extractMidashigo();
+        const midashigo = this.editor.extractMidashigo();
         if (!midashigo || midashigo.length === 0) {
             context.setHenkanMode(KakuteiMode.create(context, this.editor));
             return;
         }
 
-        let jisyoEntry = this.findCandidates(midashigo, okuri);
+        const jisyoEntry = this.findCandidates(midashigo, okuri);
         if (jisyoEntry instanceof Error) {
             context.showErrorMessage(jisyoEntry.message);
             return;
@@ -77,7 +74,7 @@ export class MidashigoMode extends AbstractMidashigoMode {
         }
 
         if (this.midashigoMode === MidashigoType.okurigana) {
-            let okuri = this.romajiInput.processInput(key.toLowerCase());
+            const okuri = this.romajiInput.processInput(key.toLowerCase());
             if (okuri.length === 0) {
                 this.editor.showRemainingRomaji(this.romajiInput.getRemainingRomaji(), true, 0);
                 return;
@@ -87,7 +84,7 @@ export class MidashigoMode extends AbstractMidashigoMode {
             this.henkan(context, okuri);
         } else {
             // in case this.midashigoMode === MidashigoType.gokan
-            let insertStr = this.romajiInput.processInput(key);
+            const insertStr = this.romajiInput.processInput(key);
             if (insertStr.length !== 0) {
                 insertOrReplaceSelection(insertStr).then((value) => {
                     this.editor.showRemainingRomaji(this.romajiInput.getRemainingRomaji(), false, 0);
@@ -119,7 +116,7 @@ export class MidashigoMode extends AbstractMidashigoMode {
 
         this.midashigoMode = MidashigoType.okurigana;
 
-        let okuri = this.romajiInput.processInput(key.toLowerCase());
+        const okuri = this.romajiInput.processInput(key.toLowerCase());
         if (okuri.length === 0) {
             this.editor.showRemainingRomaji(this.romajiInput.getRemainingRomaji(), true, 0);
             return;
@@ -135,13 +132,13 @@ export class MidashigoMode extends AbstractMidashigoMode {
 
     onSymbol(context: AbstractKanaMode, key: string): void {
         // まずはローマ字テーブルを見て、かなや記号に変換できるならば変換する
-        let kana = this.romajiInput.processInput(key);
+        const kana = this.romajiInput.processInput(key);
 
         // 以下の記号のいずれかが入力された場合には、その記号を入力するとともに，記号以前の部分について変換を始める
         // 。、．，」』］!！:：;；
 
         // "n," と入力された場合，kana が "ん、" となる．そのため、最後の1文字で変換を開始するかを決定する
-        let lastKana = kana[kana.length - 1];
+        const lastKana = kana[kana.length - 1];
 
         if (new Set(["。", "、", "．", "，", "」", "』", "］", "!", "！", ":", "：", ";", "；"]).has(lastKana)) {
             // 最後の1文字を除いた kana を挿入
@@ -155,7 +152,7 @@ export class MidashigoMode extends AbstractMidashigoMode {
 
         // 変換できる文字があればそれを挿入して終了
         if (kana.length > 0) {
-            let remaining = this.romajiInput.getRemainingRomaji();
+            const remaining = this.romajiInput.getRemainingRomaji();
             context.insertStringAndShowRemaining(kana, remaining, false);
             return;
         }
@@ -165,7 +162,7 @@ export class MidashigoMode extends AbstractMidashigoMode {
 
     onSpace(context: AbstractKanaMode): void {
         // "n" のように，仮名にできるローマ字がバッファに残っている場合は，仮名を入力してから変換を開始する
-        let kana = this.romajiInput.findExactKanaForRomBuffer() ?? "";
+        const kana = this.romajiInput.findExactKanaForRomBuffer() ?? "";
         this.romajiInput.reset();
         context.insertStringAndShowRemaining(kana, "", false).then(() => {
             this.henkan(context, "");

--- a/src/input-mode/henkan/MidashigoMode.ts
+++ b/src/input-mode/henkan/MidashigoMode.ts
@@ -6,7 +6,7 @@ import { getGlobalJisyo } from "../../jisyo/jisyo";
 import { AbstractKanaMode } from "../AbstractKanaMode";
 import { AsciiMode } from "../AsciiMode";
 import { ZeneiMode } from "../ZeneiMode";
-import { AbstractHenkanMode } from "./AbstractHenkanMode";
+import { AbstractMidashigoMode } from "./AbstractMidashigoMode";
 import { InlineHenkanMode } from "./InlineHenkanMode";
 import { KakuteiMode } from "./KakuteiMode";
 
@@ -15,7 +15,7 @@ export enum MidashigoType {
     okurigana // ▽あ*k
 }
 
-export class MidashigoMode extends AbstractHenkanMode {
+export class MidashigoMode extends AbstractMidashigoMode {
     private romajiInput: RomajiInput;
     midashigoMode: MidashigoType = MidashigoType.gokan;
 
@@ -45,11 +45,7 @@ export class MidashigoMode extends AbstractHenkanMode {
         }
     }
 
-    getRomajiInput(): RomajiInput {
-        return this.romajiInput;
-    }
-
-    henkan(context: AbstractKanaMode, okuri: string, optionalSuffix?: string): void {
+    private henkan(context: AbstractKanaMode, okuri: string, optionalSuffix?: string): void {
         let midashigo = this.editor.extractMidashigo();
         if (!midashigo || midashigo.length === 0) {
             context.setHenkanMode(KakuteiMode.create(context, this.editor));
@@ -163,7 +159,7 @@ export class MidashigoMode extends AbstractHenkanMode {
             context.insertStringAndShowRemaining(kana, remaining, false);
             return;
         }
-        
+
         throw new Error("Method not implemented.");
     }
 


### PR DESCRIPTION
SKK Abbrev モードを実現した．
確定モードで / を入力することで Abbrev モードに遷移し，英数記号などからなる見出し語を入力し，スペースキーで変換することができる．

closes #15