### PR TITLE
拡張機能のアクティベーションが実行されることによるテストケースのタイムアウトを解消

### DIFF
--- a/src/tests/integration/suite/index.ts
+++ b/src/tests/integration/suite/index.ts
@@ -8,6 +8,9 @@ export function run(): Promise<void> {
 		ui: 'tdd',
 		color: true
 	});
+	
+	// Set a timeout to prevent test case timeout due to extension activation
+	mocha.timeout(10_000); // 10 seconds
 
 	const testsRoot = path.resolve(__dirname, '..');
 


### PR DESCRIPTION
拡張機能のアクティベーション処理が，最初に実行されるテストケースので暗黙に実行されるが，これによりデフォルトの時間制限 (2000ms) を越えてしまうことがあった．
時間制限の値を 5 倍の 10 秒にすることで，タイムアウトによるテスト失敗を防ぐ．