### PR TITLE
辞書登録機能の実現

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
         "title": "Cursor Move"
       },
       {
-        "command": "skk.registerCandidate",
-        "title": "Register Candidate"
+        "command": "skk.registerMidashigo",
+        "title": "Register new Midashigo from the current editor"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
       {
         "command": "skk.cursorMove",
         "title": "Cursor Move"
+      },
+      {
+        "command": "skk.registerCandidate",
+        "title": "Register Candidate"
       }
     ],
     "keybindings": [
@@ -481,6 +485,11 @@
         "command": "skk.backspaceInput",
         "when": "editorTextFocus",
         "key": "backspace"
+      },
+      {
+        "command": "skk.registerCandidate",
+        "when": "editorTextFocus",
+        "key": "ctrl+alt+r"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "contributes": {
     "commands": [
       {
+        "command": "skk.nop",
+        "title": "Nothing to do. Just for activating the extension."
+      },
+      {
         "command": "skk.upperAlphabetInput",
         "title": "Upper Alphabet Input"
       },

--- a/package.json
+++ b/package.json
@@ -491,7 +491,7 @@
         "key": "backspace"
       },
       {
-        "command": "skk.registerCandidate",
+        "command": "skk.registerMidashigo",
         "when": "editorTextFocus",
         "key": "ctrl+alt+r"
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,7 @@ function findInputMode(): IInputMode {
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext) {
-	await jisyo.init(context.globalState);
+	jisyo.init(context.globalState);
 
 	// vscode.window.showInformationMessage("SKK: start");
 
@@ -65,62 +65,61 @@ export async function activate(context: vscode.ExtensionContext) {
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
-	let lowerAlphaInput = vscode.commands.registerCommand('skk.lowerAlphabetInput', (key: string) => {
+	const lowerAlphaInput = vscode.commands.registerCommand('skk.lowerAlphabetInput', (key: string) => {
 		findInputMode().lowerAlphabetInput(key);
 		updatePreviousEditorAndSelections();
 	});
 	context.subscriptions.push(lowerAlphaInput);
 
-
-	let upperAlphaInput = vscode.commands.registerCommand('skk.upperAlphabetInput', (key: string) => {
+	const upperAlphaInput = vscode.commands.registerCommand('skk.upperAlphabetInput', (key: string) => {
 		findInputMode().upperAlphabetInput(key);
 		updatePreviousEditorAndSelections();
 	});
 	context.subscriptions.push(upperAlphaInput);
 
-	let spaceInput = vscode.commands.registerCommand('skk.spaceInput', () => {
+	const spaceInput = vscode.commands.registerCommand('skk.spaceInput', () => {
 		findInputMode().spaceInput();
 		updatePreviousEditorAndSelections();
 	});
 	context.subscriptions.push(spaceInput);
 
-	let ctrlJInput = vscode.commands.registerCommand('skk.ctrlJInput', () => {
+	const ctrlJInput = vscode.commands.registerCommand('skk.ctrlJInput', () => {
 		findInputMode().ctrlJInput();
 		updatePreviousEditorAndSelections();
 	});
 	context.subscriptions.push(ctrlJInput);
 
-	let ctrlGInput = vscode.commands.registerCommand('skk.ctrlGInput', () => {
+	const ctrlGInput = vscode.commands.registerCommand('skk.ctrlGInput', () => {
 		findInputMode().ctrlGInput();
 		updatePreviousEditorAndSelections();
 	});
 	context.subscriptions.push(ctrlGInput);
 
-	let enterInput = vscode.commands.registerCommand('skk.enterInput', () => {
+	const enterInput = vscode.commands.registerCommand('skk.enterInput', () => {
 		findInputMode().enterInput();
 		updatePreviousEditorAndSelections();
 	});
 	context.subscriptions.push(enterInput);
 
-	let backspaceInput = vscode.commands.registerCommand('skk.backspaceInput', () => {
+	const backspaceInput = vscode.commands.registerCommand('skk.backspaceInput', () => {
 		findInputMode().backspaceInput();
 		updatePreviousEditorAndSelections();
 	});
 	context.subscriptions.push(backspaceInput);
 
-	let numberInput = vscode.commands.registerCommand('skk.numberInput', (key: string) => {
+	const numberInput = vscode.commands.registerCommand('skk.numberInput', (key: string) => {
 		findInputMode().numberInput(key);
 		updatePreviousEditorAndSelections();
 	});
 	context.subscriptions.push(numberInput);
 
-	let symbolInput = vscode.commands.registerCommand('skk.symbolInput', (key: string) => {
+	const symbolInput = vscode.commands.registerCommand('skk.symbolInput', (key: string) => {
 		findInputMode().symbolInput(key);
 		updatePreviousEditorAndSelections();
 	});
 	context.subscriptions.push(symbolInput);
 
-	let registerCandidateCommand = vscode.commands.registerCommand('skk.registerCandidate', async () => {
+	const registerCandidateCommand = vscode.commands.registerCommand('skk.registerCandidate', async () => {
 		/**
 		 * 現在のエディタの内容が下の形式にあてはまっている場合に、その内容をユーザ辞書に登録する。
 		 * 読みが「あt」で単語が「合」の場合:
@@ -172,6 +171,8 @@ export async function activate(context: vscode.ExtensionContext) {
 		// close the editor
 		await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
 	});
+	context.subscriptions.push(registerCandidateCommand);
+
 	vscode.window.onDidChangeTextEditorSelection(event => {
 		// On cursor moves in event.textEditor
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,6 +51,7 @@ function findInputMode(): IInputMode {
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext) {
+	// Initialize jisyo asynchronusly
 	jisyo.init(context.globalState);
 
 	// vscode.window.showInformationMessage("SKK: start");
@@ -65,6 +66,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
+	const nop = vscode.commands.registerCommand('skk.nop', () => {
+		// nothing to do
+	});
+	context.subscriptions.push(nop);
+
 	const lowerAlphaInput = vscode.commands.registerCommand('skk.lowerAlphabetInput', (key: string) => {
 		findInputMode().lowerAlphabetInput(key);
 		updatePreviousEditorAndSelections();
@@ -159,7 +165,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			return;
 		}
 
-		const newCandidateList = [{ word, annotation: '' }, ...jisyo.getGlobalJisyo().get(yomi) || []];
+		const newCandidateList = [{ word, annotation: undefined }, ...jisyo.getGlobalJisyo().get(yomi) || []];
 		// dedup
 		const deduped = newCandidateList.filter((candidate, index, self) => self.findIndex(c => c.word === candidate.word) === index);
 		jisyo.getGlobalJisyo().set(yomi, deduped);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,6 +120,58 @@ export async function activate(context: vscode.ExtensionContext) {
 	});
 	context.subscriptions.push(symbolInput);
 
+	let registerCandidateCommand = vscode.commands.registerCommand('skk.registerCandidate', async () => {
+		/**
+		 * 現在のエディタの内容が下の形式にあてはまっている場合に、その内容をユーザ辞書に登録する。
+		 * 読みが「あt」で単語が「合」の場合:
+		 * 読み:あt
+		 * 単語:合
+		 * 
+		 * ユーザ辞書のキー「あt」に対して，値「合」を先頭に追加する。
+		 * その後，エディタを閉じる。
+		 */
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			return;
+		}
+		const document = editor.document;
+		const content = document.getText();
+		const lines = content.split('\n');
+
+		// フォーマットの確認
+		if (lines.length < 2 // 2行以上でなければならない
+			|| lines.slice(2).some(line => line.trim() !== '') // 3行目以降は空でなければならない
+			|| lines[0].slice(0, 3) !== "読み:" // 1行目は「読み:」で始まらなければならない
+			|| lines[1].slice(0, 3) !== "単語:" // 2行目は「単語:」で始まらなければならない
+		) {
+			vscode.window.showErrorMessage("SKK: 辞書登録できません。フォーマットが不正です。");
+			return;
+		}
+
+		const yomi = lines[0].slice(3);
+		const word = lines[1].slice(3);
+
+		if (yomi === '') {
+			vscode.window.showErrorMessage("SKK: 辞書登録できません。読みが空です。");
+			return;
+		}
+		if (word === '') {
+			vscode.window.showErrorMessage("SKK: 辞書登録できません。単語が空です。");
+			return;
+		}
+
+		const newCandidateList = [{ word, annotation: '' }, ...jisyo.getGlobalJisyo().get(yomi) || []];
+		// dedup
+		const deduped = newCandidateList.filter((candidate, index, self) => self.findIndex(c => c.word === candidate.word) === index);
+		jisyo.getGlobalJisyo().set(yomi, deduped);
+
+		// clear all text in the editor
+		await editor.edit(editBuilder => {
+			editBuilder.delete(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(document.lineCount, 0)));
+		});
+		// close the editor
+		await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+	});
 	vscode.window.onDidChangeTextEditorSelection(event => {
 		// On cursor moves in event.textEditor
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { IInputMode } from './input-mode/IInputMode';
 import { AsciiMode } from './input-mode/AsciiMode';
 import * as jisyo from './jisyo/jisyo';
+import { registerMidashigo } from './input-mode/henkan/RegistrationEditor';
 
 var timestampOfCursorMoveCausedByKeyInput: number | undefined = undefined;
 
@@ -125,57 +126,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	});
 	context.subscriptions.push(symbolInput);
 
-	const registerCandidateCommand = vscode.commands.registerCommand('skk.registerCandidate', async () => {
-		/**
-		 * 現在のエディタの内容が下の形式にあてはまっている場合に、その内容をユーザ辞書に登録する。
-		 * 読みが「あt」で単語が「合」の場合:
-		 * 読み:あt
-		 * 単語:合
-		 * 
-		 * ユーザ辞書のキー「あt」に対して，値「合」を先頭に追加する。
-		 * その後，エディタを閉じる。
-		 */
-		const editor = vscode.window.activeTextEditor;
-		if (!editor) {
-			return;
-		}
-		const document = editor.document;
-		const content = document.getText();
-		const lines = content.split('\n');
-
-		// フォーマットの確認
-		if (lines.length < 2 // 2行以上でなければならない
-			|| lines.slice(2).some(line => line.trim() !== '') // 3行目以降は空でなければならない
-			|| lines[0].slice(0, 3) !== "読み:" // 1行目は「読み:」で始まらなければならない
-			|| lines[1].slice(0, 3) !== "単語:" // 2行目は「単語:」で始まらなければならない
-		) {
-			vscode.window.showErrorMessage("SKK: 辞書登録できません。フォーマットが不正です。");
-			return;
-		}
-
-		const yomi = lines[0].slice(3);
-		const word = lines[1].slice(3);
-
-		if (yomi === '') {
-			vscode.window.showErrorMessage("SKK: 辞書登録できません。読みが空です。");
-			return;
-		}
-		if (word === '') {
-			vscode.window.showErrorMessage("SKK: 辞書登録できません。単語が空です。");
-			return;
-		}
-
-		const newCandidateList = [{ word, annotation: undefined }, ...jisyo.getGlobalJisyo().get(yomi) || []];
-		// dedup
-		const deduped = newCandidateList.filter((candidate, index, self) => self.findIndex(c => c.word === candidate.word) === index);
-		jisyo.getGlobalJisyo().set(yomi, deduped);
-
-		// clear all text in the editor
-		await editor.edit(editBuilder => {
-			editBuilder.delete(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(document.lineCount, 0)));
-		});
-		// close the editor
-		await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+	const registerCandidateCommand = vscode.commands.registerCommand('skk.registerMidashigo', async () => {
+		await registerMidashigo();
 	});
 	context.subscriptions.push(registerCandidateCommand);
 

--- a/src/input-mode/henkan/AbbrevMode.ts
+++ b/src/input-mode/henkan/AbbrevMode.ts
@@ -39,7 +39,7 @@ export class AbbrevMode extends AbstractMidashigoMode {
             return;
         }
 
-        context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, jisyoEntry, optionalSuffix));
+        context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, "", jisyoEntry, optionalSuffix));
     }
 
     onLowerAlphabet(context: AbstractKanaMode, key: string): void {

--- a/src/input-mode/henkan/InlineHenkanMode.ts
+++ b/src/input-mode/henkan/InlineHenkanMode.ts
@@ -9,6 +9,7 @@ import { AbstractHenkanMode } from "./AbstractHenkanMode";
 import { KakuteiMode } from "./KakuteiMode";
 import { MenuHenkanMode } from "./MenuHenkanMode";
 import { AbstractMidashigoMode } from "./AbstractMidashigoMode";
+import { openRegistrationEditor } from './RegistrationEditor';
 
 export class InlineHenkanMode extends AbstractHenkanMode {
     private readonly prevMode: AbstractMidashigoMode;
@@ -125,7 +126,7 @@ export class InlineHenkanMode extends AbstractHenkanMode {
     }
     onSpace(context: AbstractKanaMode): void {
         if (this.candidateIndex + 1 >= this.jisyoEntry.getCandidateList().length) {
-            this.openRegistrationEditor(context);
+            openRegistrationEditor(this.getMidashigo());
             return;
         }
 
@@ -167,17 +168,5 @@ export class InlineHenkanMode extends AbstractHenkanMode {
 
     getMidashigo() {
         return this.origMidashigo + this.okuriAlphabet;
-    }
-
-    private async openRegistrationEditor(context: AbstractKanaMode): Promise<void> {
-        const yomi = this.getMidashigo();
-        const content = `読み:${yomi}\n単語:`;
-        const doc = await vscode.workspace.openTextDocument({ content, language: "plaintext" });
-        // open the document in a new editor and set cursor just after "単語:"
-        await vscode.window.showTextDocument(doc, { preview: false }).then((editor) => {
-            const position = new vscode.Position(1, 3);
-            editor.selection = new vscode.Selection(position, position);
-        });
-        // Then instruct user to run "skk.tourokuCandidate"
     }
 }

--- a/src/input-mode/henkan/InlineHenkanMode.ts
+++ b/src/input-mode/henkan/InlineHenkanMode.ts
@@ -10,6 +10,7 @@ import { KakuteiMode } from "./KakuteiMode";
 import { MenuHenkanMode } from "./MenuHenkanMode";
 import { AbstractMidashigoMode } from "./AbstractMidashigoMode";
 import { openRegistrationEditor } from './RegistrationEditor';
+import { toHiragana } from 'wanakana';
 
 export class InlineHenkanMode extends AbstractHenkanMode {
     private readonly prevMode: AbstractMidashigoMode;
@@ -167,6 +168,6 @@ export class InlineHenkanMode extends AbstractHenkanMode {
     }
 
     getMidashigo() {
-        return this.origMidashigo + this.okuriAlphabet;
+        return toHiragana(this.origMidashigo) + this.okuriAlphabet;
     }
 }

--- a/src/input-mode/henkan/MenuHenkanMode.ts
+++ b/src/input-mode/henkan/MenuHenkanMode.ts
@@ -5,6 +5,7 @@ import { KakuteiMode } from "./KakuteiMode";
 import { InlineHenkanMode } from "./InlineHenkanMode";
 import { IEditor } from "../../editor/IEditor";
 import { Entry } from "../../jisyo/entry";
+import { openRegistrationEditor } from './RegistrationEditor';
 
 export class MenuHenkanMode extends AbstractHenkanMode {
     private readonly prevMode: InlineHenkanMode;
@@ -97,7 +98,7 @@ export class MenuHenkanMode extends AbstractHenkanMode {
 
     onSymbol(context: AbstractKanaMode, key: string): void {
         if (key === '.') {
-            this.openRegistrationEditor(context);
+            openRegistrationEditor(this.prevMode.getMidashigo());
             return;
         }
         throw new Error("Method not implemented.");
@@ -105,7 +106,7 @@ export class MenuHenkanMode extends AbstractHenkanMode {
 
     onSpace(context: AbstractKanaMode): void {
         if (this.candidateIndex + this.nDisplayCandidates >= this.jisyoEntry.getCandidateList().length) {
-            this.openRegistrationEditor(context);
+            openRegistrationEditor(this.prevMode.getMidashigo());
             return;
         }
 
@@ -137,14 +138,6 @@ export class MenuHenkanMode extends AbstractHenkanMode {
     }
 
     private async openRegistrationEditor(context: AbstractKanaMode): Promise<void> {
-        const yomi = this.prevMode.getMidashigo();
-        const content = `読み:${yomi}\n単語:`;
-        const doc = await vscode.workspace.openTextDocument({ content, language: "plaintext" });
-        // open the document in a new editor and set cursor just after "単語:"
-        await vscode.window.showTextDocument(doc, { preview: false }).then((editor) => {
-            const position = new vscode.Position(1, 3);
-            editor.selection = new vscode.Selection(position, position);
-        });
-        // Then instruct user to run "skk.tourokuCandidate"
+        await openRegistrationEditor(this.prevMode.getMidashigo());
     }
 }

--- a/src/input-mode/henkan/MenuHenkanMode.ts
+++ b/src/input-mode/henkan/MenuHenkanMode.ts
@@ -136,8 +136,4 @@ export class MenuHenkanMode extends AbstractHenkanMode {
         this.editor.hideCandidateList();
         this.prevMode.returnToMidashigoMode(context);
     }
-
-    private async openRegistrationEditor(context: AbstractKanaMode): Promise<void> {
-        await openRegistrationEditor(this.prevMode.getMidashigo());
-    }
 }

--- a/src/input-mode/henkan/MidashigoMode.ts
+++ b/src/input-mode/henkan/MidashigoMode.ts
@@ -10,6 +10,7 @@ import { ZeneiMode } from "../ZeneiMode";
 import { AbstractMidashigoMode } from "./AbstractMidashigoMode";
 import { InlineHenkanMode } from "./InlineHenkanMode";
 import { KakuteiMode } from "./KakuteiMode";
+import { openRegistrationEditor } from './RegistrationEditor';
 
 export enum MidashigoType {
     gokan, // ▽あ
@@ -48,17 +49,6 @@ export class MidashigoMode extends AbstractMidashigoMode {
         return {key, keyForLookup};
     }
 
-    private async openRegistrationEditor(yomi: string): Promise<void> {
-        const content = `読み:${yomi}\n単語:`;
-        const doc = await vscode.workspace.openTextDocument({ content, language: "plaintext" });
-        // open the document in a new editor and set cursor just after "単語:"
-        await vscode.window.showTextDocument(doc, { preview: false }).then((editor) => {
-            const position = new vscode.Position(1, 3);
-            editor.selection = new vscode.Selection(position, position);
-        });
-        // Then instruct user to run "skk.tourokuCandidate"
-    }
-
     private henkan(context: AbstractKanaMode, okuri: string, optionalSuffix?: string): void {
         const midashigo = this.editor.extractMidashigo();
         if (!midashigo || midashigo.length === 0) {
@@ -69,7 +59,7 @@ export class MidashigoMode extends AbstractMidashigoMode {
         const jisyoEntry = this.findCandidates(midashigo, okuri);
         if (jisyoEntry === undefined) {
             const {keyForLookup} = this.createJisyoKey(midashigo, okuri);
-            this.openRegistrationEditor(keyForLookup);
+            openRegistrationEditor(keyForLookup);
             return;
         }
 

--- a/src/input-mode/henkan/MidashigoMode.ts
+++ b/src/input-mode/henkan/MidashigoMode.ts
@@ -31,8 +31,8 @@ export class MidashigoMode extends AbstractMidashigoMode {
     }
 
     findCandidates(midashigo: string, okuri: string): Entry | Error {
-        const okuriAlpha = okuri.length > 0 ? calcFirstAlphabetOfOkurigana(okuri) : "";
-        const key = midashigo + okuriAlpha;
+        const okuriAlphabet = okuri.length > 0 ? (calcFirstAlphabetOfOkurigana(okuri) || "") : "";
+        const key = midashigo + okuriAlphabet;
         const keyForLookup = this.romajiInput.convertKanaToHiragana(key);
         const candidates = getGlobalJisyo().get(keyForLookup);
         if (candidates === undefined) {
@@ -55,7 +55,8 @@ export class MidashigoMode extends AbstractMidashigoMode {
             return;
         }
 
-        context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, jisyoEntry, optionalSuffix));
+        const okuriAlphabet = okuri.length > 0 ? (calcFirstAlphabetOfOkurigana(okuri) || "") : "";
+        context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, okuriAlphabet, jisyoEntry, optionalSuffix));
     }
 
     onLowerAlphabet(context: AbstractKanaMode, key: string): void {

--- a/src/input-mode/henkan/RegistrationEditor.ts
+++ b/src/input-mode/henkan/RegistrationEditor.ts
@@ -1,0 +1,68 @@
+
+import * as vscode from 'vscode';
+import { getGlobalJisyo } from '../../jisyo/jisyo';
+
+export async function openRegistrationEditor(yomi: string): Promise<void> {
+    const content = `読み:${yomi}\n単語:`;
+    const doc = await vscode.workspace.openTextDocument({ content, language: 'plaintext' });
+
+    await vscode.window.showTextDocument(doc, { preview: false }).then(async (editor) => {
+        // move cursor to the end of the document
+        vscode.commands.executeCommand('cursorBottom'); // execute asynchrously
+    });
+
+    // Then instruct user to run "skk.tourokuCandidate"
+}
+
+/**
+ * 現在のエディタの内容が下の形式にあてはまっている場合に、その内容をユーザ辞書に登録する。
+ * 例: 読みが「あt」で単語が「合」の場合:
+ * 読み:あt
+ * 単語:合
+ * 
+ * ユーザ辞書のキー「あt」に対して，値「合」を先頭に追加する。
+ * その後，エディタを閉じる。
+ */
+export async function registerMidashigo(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        return;
+    }
+    const document = editor.document;
+    const content = document.getText();
+    const lines = content.split('\n');
+
+    // フォーマットの確認
+    if (lines.length < 2 // 2行以上でなければならない
+        || lines[0].slice(0, 3) !== "読み:" // 1行目は「読み:」で始まらなければならない
+        || lines[1].slice(0, 3) !== "単語:" // 2行目は「単語:」で始まらなければならない
+        || lines.slice(2).some(line => line.trim() !== '') // 3行目以降は空でなければならない
+    ) {
+        vscode.window.showErrorMessage("SKK: 辞書登録できません。フォーマットが不正です。");
+        return;
+    }
+
+    const yomi = lines[0].slice(3);
+    const word = lines[1].slice(3);
+
+    if (yomi === '') {
+        vscode.window.showErrorMessage("SKK: 辞書登録できません。読みが空です。");
+        return;
+    }
+    if (word === '') {
+        vscode.window.showErrorMessage("SKK: 辞書登録できません。単語が空です。");
+        return;
+    }
+
+    const newCandidateList = [{ word, annotation: undefined }, ...getGlobalJisyo().get(yomi) || []];
+    // dedup
+    const deduped = newCandidateList.filter((candidate, index, self) => self.findIndex(c => c.word === candidate.word) === index);
+    getGlobalJisyo().set(yomi, deduped);
+
+    // clear all text in the editor
+    await editor.edit(editBuilder => {
+        editBuilder.delete(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(document.lineCount, 0)));
+    });
+    // close the editor
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+}

--- a/src/jisyo/jisyo.ts
+++ b/src/jisyo/jisyo.ts
@@ -10,11 +10,13 @@ const userJisyoKey = "skk.user-jisyo";
 var globalJisyo: Jisyo;
 
 export async function init(memento: vscode.Memento): Promise<void> {
+    vscode.window.showInformationMessage("SKK: initializing jisyo...");
     const cfg = vscode.workspace.getConfiguration("skk");
     const dictUrls = cfg.get<string[]>("dictUrls", ["https://raw.githubusercontent.com/skk-dev/dict/master/SKK-JISYO.L"]);
     const systemJisyos = await loadAllSystemJisyos(memento, dictUrls);
-    let userJisyo = loadOrInitUserJisyo(memento);
+    const userJisyo = loadOrInitUserJisyo(memento);
     globalJisyo = new CompositeJisyo([userJisyo, ...systemJisyos], memento);
+    vscode.window.showInformationMessage("SKK: jisyo initialized!");
 }
 
 export function getGlobalJisyo(): Jisyo {
@@ -39,7 +41,6 @@ class CompositeJisyo extends CompositeMap<string, Candidate[]> {
 function loadOrInitUserJisyo(memento: vscode.Memento): Jisyo {
     // check if local cache is available
     const cache = memento.get<Object>(userJisyoKey);
-    const now = Date.now();
     if (cache) {
         return new Map(Object.entries(cache));
     }
@@ -79,8 +80,8 @@ async function loadAllSystemJisyos(memento: vscode.Memento, urls: string[]): Pro
     });
 
     const results = await Promise.all(promises);
-    await memento.update("skk.jisyoCache", savedCache);
-    await memento.update("skk.jisyoCacheExpiries", savedExpiries);
+    memento.update("skk.jisyoCache", savedCache); // execute asynchronously
+    memento.update("skk.jisyoCacheExpiries", savedExpiries); // execute asynchronously
     return results;
 }
 
@@ -91,35 +92,6 @@ async function fetchAndDecodeDictionary(url: string): Promise<Jisyo> {
     }
     const rawJisyo = Buffer.from(await response.arrayBuffer());
     return rawSKKJisyoToJisyo(rawJisyo);
-}
-
-async function loadSystemJisyoFromUri(memento: vscode.Memento, uri: Uri): Promise<Jisyo> {
-    const systemJisyoKey = "skk.jisyo";
-    const cacheExpiryKey = "skk.jisyo-expiry";
-
-    // check if local cache is available
-    const cache = memento.get<Object>(systemJisyoKey);
-    const cacheExpiry = memento.get<number>(cacheExpiryKey);
-    const now = Date.now();
-    if (cache && cacheExpiry && now < cacheExpiry) {
-        return new Map(Object.entries(cache));
-    }
-
-    // clear cache
-    await memento.update(systemJisyoKey, undefined);
-    await memento.update(cacheExpiryKey, undefined);
-
-    // download jisyo from uri
-    const response = await fetch(uri.toString());
-    if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    const rawJisyo = Buffer.from(await response.arrayBuffer());
-
-    const jisyo = rawSKKJisyoToJisyo(rawJisyo);
-    await memento.update(systemJisyoKey, Object.fromEntries(jisyo));
-    await memento.update(cacheExpiryKey, now + 1000 * 60 * 60 * 24 * 30); // 30 days
-    return jisyo;
 }
 
 function rawSKKJisyoToJisyo(rawLines: Buffer): Jisyo {

--- a/src/jisyo/jisyo.ts
+++ b/src/jisyo/jisyo.ts
@@ -10,13 +10,11 @@ const userJisyoKey = "skk.user-jisyo";
 var globalJisyo: Jisyo;
 
 export async function init(memento: vscode.Memento): Promise<void> {
-    vscode.window.showInformationMessage("SKK: initializing jisyo...");
     const cfg = vscode.workspace.getConfiguration("skk");
     const dictUrls = cfg.get<string[]>("dictUrls", ["https://raw.githubusercontent.com/skk-dev/dict/master/SKK-JISYO.L"]);
     const systemJisyos = await loadAllSystemJisyos(memento, dictUrls);
     const userJisyo = loadOrInitUserJisyo(memento);
     globalJisyo = new CompositeJisyo([userJisyo, ...systemJisyos], memento);
-    vscode.window.showInformationMessage("SKK: jisyo initialized!");
 }
 
 export function getGlobalJisyo(): Jisyo {

--- a/src/jisyo/jisyo.ts
+++ b/src/jisyo/jisyo.ts
@@ -29,10 +29,31 @@ class CompositeJisyo extends CompositeMap<string, Candidate[]> {
         this.memento = memento;
     }
 
+    /**
+     * Register a new Midashigo to the user dictionary.
+     * @param key 
+     * @param value 
+     * @returns 
+     */
     set(key: string, value: Candidate[]): this {
         super.set(key, value);
         saveUserJisyo(this.memento, this.maps[0]);
         return this;
+    }
+
+    /**
+     * Delete a key from the user dictionary.
+     * @param key 
+     * @returns true if the key was found and deleted, false otherwise.
+     */
+    delete(key: string): boolean {
+        if (!this.maps[0].has(key)) {
+            return false;
+        }
+
+        const result = this.maps[0].delete(key);
+        saveUserJisyo(this.memento, this.maps[0]);
+        return result;
     }
 }
 

--- a/src/tests/integration/suite/Mode/mode-switch.test.ts
+++ b/src/tests/integration/suite/Mode/mode-switch.test.ts
@@ -1,8 +1,5 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { setInputMode } from '../../../../extension';
-import { AsciiMode } from '../../../../input-mode/AsciiMode';
-import { KatakanaMode } from '../../../../input-mode/KatakanaMode';
 
 suite('Switching between modes test', () => {
     setup('Open a new empty editor', async () => {

--- a/src/tests/integration/suite/henkan/registration-feature.test.ts
+++ b/src/tests/integration/suite/henkan/registration-feature.test.ts
@@ -60,7 +60,7 @@ suite('Registration feature test', async () => {
 
         // 辞書登録のフォーマットでテキストを入力し， registerCandidate コマンドを実行する
         await vscode.commands.executeCommand('type', { text: `読み:${unexistYomi}\n単語:${unexistWord}` });
-        await vscode.commands.executeCommand('skk.registerCandidate');
+        await vscode.commands.executeCommand('skk.registerMidashigo');
 
         // ユーザ辞書に登録されたことを確認する
         const candidate = getGlobalJisyo()?.get(unexistYomi);

--- a/src/tests/integration/suite/henkan/registration-feature.test.ts
+++ b/src/tests/integration/suite/henkan/registration-feature.test.ts
@@ -1,28 +1,30 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { getGlobalJisyo } from '../../../../jisyo/jisyo';
+import { expect } from 'chai';
 
 suite('Registration feature test', async () => {
-    const unexistYomi = 'りですごじめわゅょぼざゔにろせふよふ';
+    const unexistYomi = 'りですごじめわゅょぼざうにろせふよふ';
+    const unexistKatakanaYomi = 'リデスゴジメワュョボザウニロセフヨフ';
     const okuriganaAlphabet = 'Sa';
     const okuriganaAlphabetPrefix = 's';
 
     setup('新しい空のエディタを開き、見出し語が登録されていない状態にする', async () => {
         await vscode.commands.executeCommand('workbench.action.files.newUntitledFile');
+        await vscode.commands.executeCommand('skk.nop'); // skk 拡張を有効にするための何もしないコマンド呼び出し
 
-        await vscode.commands.executeCommand('skk.nop');
         const globalJisyo = getGlobalJisyo();
         globalJisyo?.delete(unexistYomi);
-        globalJisyo?.delete(unexistYomi+okuriganaAlphabetPrefix);
+        globalJisyo?.delete(unexistYomi + okuriganaAlphabetPrefix);
     });
 
     teardown('エディタを閉じ、登録された不要な見出し語を削除する', async () => {
-        await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        await vscode.commands.executeCommand('skk.nop'); // skk 拡張を有効にするための何もしないコマンド呼び出し
 
-        await vscode.commands.executeCommand('skk.nop');
         const globalJisyo = getGlobalJisyo();
         globalJisyo?.delete(unexistYomi);
-        globalJisyo?.delete(unexistYomi+okuriganaAlphabetPrefix);
+        globalJisyo?.delete(unexistYomi + okuriganaAlphabetPrefix);
     });
 
     test('存在しない送りなし見出し語を変換しようとすると、辞書登録エディタが開く', async () => {
@@ -38,19 +40,22 @@ suite('Registration feature test', async () => {
         // エディタに，辞書に存在しない語の読みを入力する
         await vscode.commands.executeCommand('type', { text: unexistYomi });
 
-        // スペースキーを入力して、見出し語の変換を試みる
-        await vscode.commands.executeCommand('skk.spaceInput');
-
         // 新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
-        return new Promise(resolve => {
-            const disposable = vscode.workspace.onDidChangeTextDocument(async e => {
-                if (e.document !== document) {
-                    disposable.dispose();
-                    assert.equal(e.document.getText(), `読み:${unexistYomi}\n単語:`);
-                    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+        return new Promise((resolve, reject) => {
+            const disposable = vscode.workspace.onDidOpenTextDocument(async newDocument => {
+                disposable.dispose();
+                try {
+                    assert.equal(newDocument.getText(), `読み:${unexistYomi}\n単語:`);
+                    vscode.commands.executeCommand('workbench.action.closeActiveEditor');
                     resolve();
+                } catch (e) {
+                    reject(e);
                 }
             });
+
+            // スペースキーを入力して、見出し語の変換を試みる
+            vscode.commands.executeCommand('skk.spaceInput');
+            // onDidOpenTextDocument が発火するはず
         });
     });
 
@@ -64,8 +69,10 @@ suite('Registration feature test', async () => {
         // Q キーを入力して、見出し語モードに切り替える
         await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Q');
 
-        // エディタに，辞書に存在しない語の読みを入力する
+        // エディタに，辞書に存在しない語の読みの語感を入力する
         await vscode.commands.executeCommand('type', { text: unexistYomi });
+
+        // エディタに，辞書に存在しない語の読みの送り仮名を入力し、変換を試みる
         for (const c of okuriganaAlphabet) {
             if (c === c.toUpperCase()) {
                 await vscode.commands.executeCommand('skk.upperAlphabetInput', c);
@@ -74,23 +81,27 @@ suite('Registration feature test', async () => {
             }
         }
 
-        // スペースキーを入力して、見出し語の変換を試みる
-        await vscode.commands.executeCommand('skk.spaceInput');
-
         // 新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
-        return new Promise(resolve => {
-            const disposable = vscode.workspace.onDidChangeTextDocument(async e => {
-                if (e.document !== document) {
-                    disposable.dispose();
-                    assert.equal(e.document.getText(), `読み:${unexistYomi+okuriganaAlphabetPrefix}\n単語:`);
-                    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+        return new Promise((resolve, reject) => {
+            const disposable = vscode.workspace.onDidOpenTextDocument(async newDocument => {
+                disposable.dispose();
+                try {
+                    expect(newDocument.getText()).equal(`読み:${unexistYomi + okuriganaAlphabetPrefix}\n単語:`);
+                    vscode.commands.executeCommand('workbench.action.closeActiveEditor');
                     resolve();
+                } catch (e) {
+                    reject(e);
                 }
             });
+
+            // FIXME: 非同期処理によって確率的に失敗する．本来は最後のアルファベットを入力する前に設定する onDidChangeTextDocument で実行すべき
+            // スペースキーを入力して、見出し語の変換を試みる
+            vscode.commands.executeCommand('skk.spaceInput');
+            // onDidOpenTextDocument が発火するはず
         });
     });
 
-    test('存在する見出し語候補の最後まで到達すると、辞書登録エディタが開く', async () => {
+    test('存在する送りなし見出し語候補の最後まで到達すると、辞書登録エディタが開く', async () => {
         const document = vscode.window.activeTextEditor?.document;
         assert.notEqual(document, undefined);
 
@@ -107,21 +118,124 @@ suite('Registration feature test', async () => {
         // エディタに，辞書に存在しない語の読みを入力する
         await vscode.commands.executeCommand('type', { text: unexistYomi });
 
+        // 次の入力によって、1つ目の候補が表示されたら実行する処理
+        const disposable1 = vscode.workspace.onDidChangeTextDocument(e => {
+            disposable1.dispose();
+            // 1つ目の候補が出ている状態で、さらにスペースキーを入力する
+            vscode.commands.executeCommand('skk.spaceInput');
+
+            // 候補の最後でスペースを押したので onDidOpenTextDocument が呼ばれるはずである
+        });
+
+        // 2回目のスペース入力によって新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
+        return new Promise((resolve, reject) => {
+            const disposable = vscode.workspace.onDidOpenTextDocument(async newDocument => {
+                disposable.dispose();
+                try {
+                    expect(newDocument).not.equal(document, '新しいエディタが開かれている');
+                    expect(newDocument.getText()).equal(`読み:${unexistYomi}\n単語:`);
+                    vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+                    resolve();
+                } catch (e) {
+                    reject(e);
+                }
+            });
+
+            // スペースキーを入力して、見出し語の変換を開始する
+            vscode.commands.executeCommand('skk.spaceInput');
+            // 1つ目の候補が表示され、 onDidChangeTextDocument が呼ばれるはずである
+        });
+    });
+
+    test('カタカナで入力した存在する送りなし見出し語候補の最後まで到達すると、辞書登録エディタが開く', async () => {
+        const document = vscode.window.activeTextEditor?.document;
+        assert.notEqual(document, undefined);
+
+        // unexistYomi に対応する候補を1つ登録する
+        const existWord = '候補1';
+        getGlobalJisyo().set(unexistYomi, [{ word: existWord, annotation: undefined }]);
+
+        // ひらがなモードに切り替える
+        await vscode.commands.executeCommand('skk.ctrlJInput');
+
+        // カタカナモードに切り替える
+        await vscode.commands.executeCommand('skk.lowerAlphabetInput', 'q');
+
+        // Q キーを入力して、見出し語モードに切り替える
+        await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Q');
+
+        // エディタに，辞書に存在しない語の読みを入力する
+        await vscode.commands.executeCommand('type', { text: unexistKatakanaYomi });
+
         // スペースキーを入力して、見出し語の変換を開始する
         await vscode.commands.executeCommand('skk.spaceInput');
+
+        // 次の入力によって、1つ目の候補が表示されたら実行する処理
+        const disposable1 = vscode.workspace.onDidChangeTextDocument(e => {
+            disposable1.dispose();
+            // 1つ目の候補が出ている状態で、さらにスペースキーを入力する
+            vscode.commands.executeCommand('skk.spaceInput');
+
+            // 候補の最後でスペースを押したので onDidOpenTextDocument が呼ばれるはずである
+        });
+
+        // 2回目のスペース入力によって新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
+        return new Promise((resolve, reject) => {
+            const disposable = vscode.workspace.onDidOpenTextDocument(async newDocument => {
+                disposable.dispose();
+                try {
+                    expect(newDocument.getText()).equal(`読み:${unexistYomi}\n単語:`);
+                    vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+                    resolve();
+                } catch (e) {
+                    reject(e);
+                }
+            });
+
+            // スペースキーを入力して、見出し語の変換を開始する
+            vscode.commands.executeCommand('skk.spaceInput');
+            // 1つ目の候補が表示され、 onDidChangeTextDocument が呼ばれるはずである
+        });
+    });
+
+    test('存在する送りあり見出し語候補の最後まで到達すると、辞書登録エディタが開く', async () => {
+        const document = vscode.window.activeTextEditor?.document;
+        assert.notEqual(document, undefined);
+
+        // 存在しない送りなし見出し語の候補を1つ登録する
+        const existWord = '候補1';
+        getGlobalJisyo().set(unexistYomi + okuriganaAlphabetPrefix, [{ word: existWord, annotation: undefined }]);
+
+        // ひらがなモードに切り替える
+        await vscode.commands.executeCommand('skk.ctrlJInput');
+
+        // Q キーを入力して、見出し語モードに切り替える
+        await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Q');
+
+        // エディタに，辞書に存在しない語の語幹を入力する
+        await vscode.commands.executeCommand('type', { text: unexistYomi });
+
+        // エディタに，辞書に存在しない語の読みの送り仮名を入力し、変換を開始する
+        for (const c of okuriganaAlphabet) {
+            if (c === c.toUpperCase()) {
+                await vscode.commands.executeCommand('skk.upperAlphabetInput', c);
+            } else {
+                await vscode.commands.executeCommand('skk.lowerAlphabetInput', c);
+            }
+        }
 
         const disposable1 = await vscode.workspace.onDidChangeTextDocument(async e => {
             disposable1.dispose();
             // 1つ目の候補が出ている状態で、さらにスペースキーを入力する
             await vscode.commands.executeCommand('skk.spaceInput');
         });
-        
+
         // 新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
         return new Promise(resolve => {
             const disposable = vscode.workspace.onDidChangeTextDocument(async e => {
                 if (e.document !== document) {
                     disposable.dispose();
-                    assert.equal(e.document.getText(), `読み:${unexistYomi}\n単語:`);
+                    assert.equal(e.document.getText(), `読み:${unexistYomi + okuriganaAlphabetPrefix}\n単語:`);
                     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
                     resolve();
                 }
@@ -129,25 +243,34 @@ suite('Registration feature test', async () => {
         });
     });
 
-
     test('辞書登録エディタで見出し語を登録すると、ユーザ辞書に見出し語が登録される', async () => {
         const unexistWord = 'かおたへちぶぬもほゃぢめろめちゅのめ';
 
-        // 念のため、現在のドキュメントが空であることを確認する
-        const document = vscode.window.activeTextEditor?.document;
-        assert.notEqual(document, undefined);
-        assert.equal(document?.getText(), '');
-
-        // 辞書登録のフォーマットでテキストを入力し， registerCandidate コマンドを実行する
+        // 辞書登録のフォーマットに従ったテキストを入力する
         await vscode.commands.executeCommand('type', { text: `読み:${unexistYomi}\n単語:${unexistWord}` });
-        await vscode.commands.executeCommand('skk.registerMidashigo');
 
-        // ユーザ辞書に登録されたことを確認する
-        const candidate = getGlobalJisyo()?.get(unexistYomi);
-        assert.notEqual(candidate, undefined);
-        assert.equal(candidate?.length, 1);
-        assert.equal(candidate?.[0].word, unexistWord);
-        assert.equal(candidate?.[0].annotation, undefined);
+        return new Promise((resolve, reject) => {
+            const disposable = vscode.workspace.onDidCloseTextDocument(async closedDocument => {
+                disposable.dispose();
+
+                try {
+                    // ユーザ辞書に登録されたことを確認する
+                    const candidate = getGlobalJisyo()?.get(unexistYomi);
+                    expect(candidate).not.equal(undefined);
+                    expect(candidate?.length).equal(1);
+                    expect(candidate?.[0].word).equal(unexistWord);
+                    expect(candidate?.[0].annotation).equal(undefined);
+                    resolve();
+                } catch (e) {
+                    reject(e);
+                }
+            });
+
+            // 辞書登録機能を呼び出すと、辞書登録が実行されてエディタが閉じられる
+            vscode.commands.executeCommand('skk.registerMidashigo');
+            // onDidCloseTextDocument が発火するはず
+        });
+
     });
 
 });

--- a/src/tests/integration/suite/henkan/registration-feature.test.ts
+++ b/src/tests/integration/suite/henkan/registration-feature.test.ts
@@ -4,6 +4,8 @@ import { getGlobalJisyo } from '../../../../jisyo/jisyo';
 
 suite('Registration feature test', async () => {
     const unexistYomi = 'りですごじめわゅょぼざゔにろせふよふ';
+    const okuriganaAlphabet = 'Sa';
+    const okuriganaAlphabetPrefix = 's';
 
     setup('新しい空のエディタを開き、見出し語が登録されていない状態にする', async () => {
         await vscode.commands.executeCommand('workbench.action.files.newUntitledFile');
@@ -11,6 +13,7 @@ suite('Registration feature test', async () => {
         await vscode.commands.executeCommand('skk.nop');
         const globalJisyo = getGlobalJisyo();
         globalJisyo?.delete(unexistYomi);
+        globalJisyo?.delete(unexistYomi+okuriganaAlphabetPrefix);
     });
 
     teardown('エディタを閉じ、登録された不要な見出し語を削除する', async () => {
@@ -19,9 +22,10 @@ suite('Registration feature test', async () => {
         await vscode.commands.executeCommand('skk.nop');
         const globalJisyo = getGlobalJisyo();
         globalJisyo?.delete(unexistYomi);
+        globalJisyo?.delete(unexistYomi+okuriganaAlphabetPrefix);
     });
 
-    test('存在しない見出し語を変換しようとすると、辞書登録エディタが開く', async () => {
+    test('存在しない送りなし見出し語を変換しようとすると、辞書登録エディタが開く', async () => {
         const document = vscode.window.activeTextEditor?.document;
         assert.notEqual(document, undefined);
 
@@ -50,6 +54,82 @@ suite('Registration feature test', async () => {
         });
     });
 
+    test('存在しない送りあり見出し語を変換しようとすると、辞書登録エディタが開く', async () => {
+        const document = vscode.window.activeTextEditor?.document;
+        assert.notEqual(document, undefined);
+
+        // ひらがなモードに切り替える
+        await vscode.commands.executeCommand('skk.ctrlJInput');
+
+        // Q キーを入力して、見出し語モードに切り替える
+        await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Q');
+
+        // エディタに，辞書に存在しない語の読みを入力する
+        await vscode.commands.executeCommand('type', { text: unexistYomi });
+        for (const c of okuriganaAlphabet) {
+            if (c === c.toUpperCase()) {
+                await vscode.commands.executeCommand('skk.upperAlphabetInput', c);
+            } else {
+                await vscode.commands.executeCommand('skk.lowerAlphabetInput', c);
+            }
+        }
+
+        // スペースキーを入力して、見出し語の変換を試みる
+        await vscode.commands.executeCommand('skk.spaceInput');
+
+        // 新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
+        return new Promise(resolve => {
+            const disposable = vscode.workspace.onDidChangeTextDocument(async e => {
+                if (e.document !== document) {
+                    disposable.dispose();
+                    assert.equal(e.document.getText(), `読み:${unexistYomi+okuriganaAlphabetPrefix}\n単語:`);
+                    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+                    resolve();
+                }
+            });
+        });
+    });
+
+    test('存在する見出し語候補の最後まで到達すると、辞書登録エディタが開く', async () => {
+        const document = vscode.window.activeTextEditor?.document;
+        assert.notEqual(document, undefined);
+
+        // unexistYomi に対応する候補を1つ登録する
+        const existWord = '候補1';
+        getGlobalJisyo().set(unexistYomi, [{ word: existWord, annotation: undefined }]);
+
+        // ひらがなモードに切り替える
+        await vscode.commands.executeCommand('skk.ctrlJInput');
+
+        // Q キーを入力して、見出し語モードに切り替える
+        await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Q');
+
+        // エディタに，辞書に存在しない語の読みを入力する
+        await vscode.commands.executeCommand('type', { text: unexistYomi });
+
+        // スペースキーを入力して、見出し語の変換を開始する
+        await vscode.commands.executeCommand('skk.spaceInput');
+
+        const disposable1 = await vscode.workspace.onDidChangeTextDocument(async e => {
+            disposable1.dispose();
+            // 1つ目の候補が出ている状態で、さらにスペースキーを入力する
+            await vscode.commands.executeCommand('skk.spaceInput');
+        });
+        
+        // 新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
+        return new Promise(resolve => {
+            const disposable = vscode.workspace.onDidChangeTextDocument(async e => {
+                if (e.document !== document) {
+                    disposable.dispose();
+                    assert.equal(e.document.getText(), `読み:${unexistYomi}\n単語:`);
+                    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+                    resolve();
+                }
+            });
+        });
+    });
+
+
     test('辞書登録エディタで見出し語を登録すると、ユーザ辞書に見出し語が登録される', async () => {
         const unexistWord = 'かおたへちぶぬもほゃぢめろめちゅのめ';
 
@@ -69,4 +149,5 @@ suite('Registration feature test', async () => {
         assert.equal(candidate?.[0].word, unexistWord);
         assert.equal(candidate?.[0].annotation, undefined);
     });
+
 });

--- a/src/tests/integration/suite/henkan/registration-feature.test.ts
+++ b/src/tests/integration/suite/henkan/registration-feature.test.ts
@@ -1,0 +1,72 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { getGlobalJisyo } from '../../../../jisyo/jisyo';
+
+suite('Registration feature test', async () => {
+    const unexistYomi = 'りですごじめわゅょぼざゔにろせふよふ';
+
+    setup('新しい空のエディタを開き、見出し語が登録されていない状態にする', async () => {
+        await vscode.commands.executeCommand('workbench.action.files.newUntitledFile');
+
+        await vscode.commands.executeCommand('skk.nop');
+        const globalJisyo = getGlobalJisyo();
+        globalJisyo?.delete(unexistYomi);
+    });
+
+    teardown('エディタを閉じ、登録された不要な見出し語を削除する', async () => {
+        await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+
+        await vscode.commands.executeCommand('skk.nop');
+        const globalJisyo = getGlobalJisyo();
+        globalJisyo?.delete(unexistYomi);
+    });
+
+    test('存在しない見出し語を変換しようとすると、辞書登録エディタが開く', async () => {
+        const document = vscode.window.activeTextEditor?.document;
+        assert.notEqual(document, undefined);
+
+        // ひらがなモードに切り替える
+        await vscode.commands.executeCommand('skk.ctrlJInput');
+
+        // Q キーを入力して、見出し語モードに切り替える
+        await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Q');
+
+        // エディタに，辞書に存在しない語の読みを入力する
+        await vscode.commands.executeCommand('type', { text: unexistYomi });
+
+        // スペースキーを入力して、見出し語の変換を試みる
+        await vscode.commands.executeCommand('skk.spaceInput');
+
+        // 新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
+        return new Promise(resolve => {
+            const disposable = vscode.workspace.onDidChangeTextDocument(async e => {
+                if (e.document !== document) {
+                    disposable.dispose();
+                    assert.equal(e.document.getText(), `読み:${unexistYomi}\n単語:`);
+                    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+                    resolve();
+                }
+            });
+        });
+    });
+
+    test('辞書登録エディタで見出し語を登録すると、ユーザ辞書に見出し語が登録される', async () => {
+        const unexistWord = 'かおたへちぶぬもほゃぢめろめちゅのめ';
+
+        // 念のため、現在のドキュメントが空であることを確認する
+        const document = vscode.window.activeTextEditor?.document;
+        assert.notEqual(document, undefined);
+        assert.equal(document?.getText(), '');
+
+        // 辞書登録のフォーマットでテキストを入力し， registerCandidate コマンドを実行する
+        await vscode.commands.executeCommand('type', { text: `読み:${unexistYomi}\n単語:${unexistWord}` });
+        await vscode.commands.executeCommand('skk.registerCandidate');
+
+        // ユーザ辞書に登録されたことを確認する
+        const candidate = getGlobalJisyo()?.get(unexistYomi);
+        assert.notEqual(candidate, undefined);
+        assert.equal(candidate?.length, 1);
+        assert.equal(candidate?.[0].word, unexistWord);
+        assert.equal(candidate?.[0].annotation, undefined);
+    });
+});


### PR DESCRIPTION
辞書登録機能を実現しました。

存在しない見出し語を変換するか、見出し語の候補の末尾を越えたときに、新しいエディタタブが開いて辞書登録をうながします。
フォーマットに従って単語を入力した後に、 skk.registerMidashigo コマンドを実行すると、単語が登録されます。

close #16 