### PR TITLE
候補削除機能を実現しました

### DIFF
--- a/src/input-mode/henkan/CandidateDeletionMode.ts
+++ b/src/input-mode/henkan/CandidateDeletionMode.ts
@@ -25,18 +25,9 @@ export class CandidateDeletionMode extends AbstractHenkanMode {
     }
 
     onLowerAlphabet(context: AbstractKanaMode, key: string): void {
-        if (key === 'y') {
-            getGlobalJisyo().deleteCandidate(this.midashigo, this.candidate);
-            this.clearInlineDialogAndReturnToKakuteiMode(context);
-            return;
+        if (key === 'y' || key === 'n') {
+            throw new Error('Type Y or N in upper case');
         }
-
-        if (key === 'n') {
-            context.setHenkanMode(this.prevMode);
-            this.prevMode.showCandidate(context);
-            return;
-        }
-
         throw new Error('Type Y or N');
     }
 
@@ -48,7 +39,19 @@ export class CandidateDeletionMode extends AbstractHenkanMode {
     }
 
     onUpperAlphabet(context: AbstractKanaMode, key: string): void {
-        this.onLowerAlphabet(context, key.toLowerCase());
+        if (key === 'Y') {
+            getGlobalJisyo().deleteCandidate(this.midashigo, this.candidate);
+            this.clearInlineDialogAndReturnToKakuteiMode(context);
+            return;
+        }
+
+        if (key === 'N') {
+            context.setHenkanMode(this.prevMode);
+            this.prevMode.showCandidate(context);
+            return;
+        }
+
+        throw new Error('Type Y or N');
     }
 
     onCtrlG(context: AbstractKanaMode): void {

--- a/src/input-mode/henkan/CandidateDeletionMode.ts
+++ b/src/input-mode/henkan/CandidateDeletionMode.ts
@@ -1,0 +1,77 @@
+import { AbstractHenkanMode } from './AbstractHenkanMode';
+import { AbstractKanaMode } from '../AbstractKanaMode';
+import { IEditor } from '../../editor/IEditor';
+import { getGlobalJisyo } from '../../jisyo/jisyo';
+import { KakuteiMode } from './KakuteiMode';
+import { InlineHenkanMode } from './InlineHenkanMode';
+import { Candidate } from '../../jisyo/candidate';
+
+export class CandidateDeletionMode extends AbstractHenkanMode {
+    private readonly prevMode: InlineHenkanMode;
+    private readonly candidate: Candidate;
+    private readonly midashigo: string;
+
+    constructor(context: AbstractKanaMode, editor: IEditor, prevMode: InlineHenkanMode, midashigo: string, candidate: Candidate) {
+        super("Delete?", editor);
+        this.prevMode = prevMode;
+        this.midashigo = midashigo;
+        this.candidate = candidate;
+
+        this.showInlineDialog(context, this.midashigo, this.candidate);
+    }
+
+    showInlineDialog(context: AbstractKanaMode, midashigo: string, candidate: Candidate) {
+        this.editor.showCandidate(undefined, `Really delete \"${midashigo} /${candidate.word}/\"? (Y/N)`);
+    }
+
+    onLowerAlphabet(context: AbstractKanaMode, key: string): void {
+        if (key === 'y') {
+            getGlobalJisyo().deleteCandidate(this.midashigo, this.candidate);
+            this.clearInlineDialogAndReturnToKakuteiMode(context);
+            return;
+        }
+
+        if (key === 'n') {
+            context.setHenkanMode(this.prevMode);
+            this.prevMode.showCandidate(context);
+            return;
+        }
+
+        throw new Error('Type Y or N');
+    }
+
+    clearInlineDialogAndReturnToKakuteiMode(context: AbstractKanaMode) {
+        context.setHenkanMode(KakuteiMode.create(context, this.editor));
+        this.editor.clearCandidate().then(() => {
+            context.insertStringAndShowRemaining("", "", false);
+        });
+    }
+
+    onUpperAlphabet(context: AbstractKanaMode, key: string): void {
+        this.onLowerAlphabet(context, key.toLowerCase());
+    }
+
+    onCtrlG(context: AbstractKanaMode): void {
+        context.setHenkanMode(this.prevMode);
+        this.prevMode.showCandidate(context);
+    }
+
+    onNumber(context: AbstractKanaMode, key: string): void {
+        throw new Error('Type Y or N');
+    }
+    onSymbol(context: AbstractKanaMode, key: string): void {
+        throw new Error('Type Y or N');
+    }
+    onSpace(context: AbstractKanaMode): void {
+        throw new Error('Type Y or N');
+    }
+    onEnter(context: AbstractKanaMode): void {
+        throw new Error('Type Y or N');
+    }
+    onBackspace(context: AbstractKanaMode): void {
+        throw new Error('Type Y or N');
+    }
+    onCtrlJ(context: AbstractKanaMode): void {
+        throw new Error('Type Y or N');
+    }
+}

--- a/src/input-mode/henkan/InlineHenkanMode.ts
+++ b/src/input-mode/henkan/InlineHenkanMode.ts
@@ -12,6 +12,7 @@ import { AbstractMidashigoMode } from "./AbstractMidashigoMode";
 import { openRegistrationEditor } from './RegistrationEditor';
 import { toHiragana } from 'wanakana';
 import { CandidateDeletionMode } from './CandidateDeletionMode';
+import { getGlobalJisyo } from '../../jisyo/jisyo';
 
 export class InlineHenkanMode extends AbstractHenkanMode {
     private readonly prevMode: AbstractMidashigoMode;
@@ -111,7 +112,15 @@ export class InlineHenkanMode extends AbstractHenkanMode {
         }
 
         if (key === 'X') {
-            context.setHenkanMode(new CandidateDeletionMode(context, this.editor, this, this.jisyoEntry.getMidashigo(), this.jisyoEntry.getCandidateList()[this.candidateIndex]));
+            const rawMidashigo = this.getMidashigo();
+
+            // lookup the raw candidates again because entries in this.candidateList may be cooked and have okurigana.
+            const rawCandidateList = getGlobalJisyo().get(rawMidashigo);
+            if (rawCandidateList === undefined) {
+                throw new Error("Unconsistent state: Candidate list is not found in the global jisyo.");
+            }
+
+            context.setHenkanMode(new CandidateDeletionMode(context, this.editor, this, rawMidashigo, rawCandidateList[this.candidateIndex]));
             return;
         }
 

--- a/src/input-mode/henkan/InlineHenkanMode.ts
+++ b/src/input-mode/henkan/InlineHenkanMode.ts
@@ -11,7 +11,7 @@ import { MenuHenkanMode } from "./MenuHenkanMode";
 import { AbstractMidashigoMode } from "./AbstractMidashigoMode";
 import { openRegistrationEditor } from './RegistrationEditor';
 import { toHiragana } from 'wanakana';
-import { getGlobalJisyo } from '../../jisyo/jisyo';
+import { CandidateDeletionMode } from './CandidateDeletionMode';
 
 export class InlineHenkanMode extends AbstractHenkanMode {
     private readonly prevMode: AbstractMidashigoMode;
@@ -110,23 +110,10 @@ export class InlineHenkanMode extends AbstractHenkanMode {
             return;
         }
 
-        // in case "X" is input, the current candidate is asked to be deleted from the jisyo
         if (key === 'X') {
-            const midashigoToBeDeleted = this.getMidashigo();
-            const candidateToBeDeleted = this.jisyoEntry.getRawCandidateList()[this.candidateIndex];
-
-            // confirm to delete the candidate
-            const result = vscode.window.showInformationMessage(`Delete "${midashigoToBeDeleted} ${candidateToBeDeleted.word}" from the user dictionary?`, "Yes", "No");
-            result.then((value) => {
-                if (value === "Yes") {
-                    getGlobalJisyo().deleteCandidate(midashigoToBeDeleted, candidateToBeDeleted);
-                    this.clearMidashigoAndReturnToKakuteiMode(context);
-                    return;
-                }
-            });
+            context.setHenkanMode(new CandidateDeletionMode(context, this.editor, this, this.jisyoEntry.getMidashigo(), this.jisyoEntry.getCandidateList()[this.candidateIndex]));
             return;
         }
-
 
         // other keys
         this.jisyoEntry.onCandidateSelected(this.candidateIndex);

--- a/src/jisyo/entry.ts
+++ b/src/jisyo/entry.ts
@@ -23,7 +23,7 @@ export class Entry {
         return this.midashigo;
     }
 
-    getCandidateList(): Candidate[] {
+    getCandidateList(): ReadonlyArray<Candidate> {
         return this.cookedCandidateList;
     }
 
@@ -36,5 +36,9 @@ export class Entry {
         // Register reordered candidate list to the jisyo.
         const newCandidateList = [this.rawCandidateList[index]].concat(this.rawCandidateList.filter((_, i) => i !== index));
         getGlobalJisyo().set(this.midashigo, newCandidateList);
+    }
+
+    getRawCandidateList(): ReadonlyArray<Candidate> {
+        return this.rawCandidateList;
     }
 }

--- a/src/jisyo/jisyo.ts
+++ b/src/jisyo/jisyo.ts
@@ -7,7 +7,7 @@ type Jisyo = Map<string, Candidate[]>;
 
 const userJisyoKey = "skk.user-jisyo";
 
-var globalJisyo: Jisyo;
+var globalJisyo: CompositeJisyo;
 
 export async function init(memento: vscode.Memento): Promise<void> {
     const cfg = vscode.workspace.getConfiguration("skk");
@@ -17,7 +17,7 @@ export async function init(memento: vscode.Memento): Promise<void> {
     globalJisyo = new CompositeJisyo([userJisyo, ...systemJisyos], memento);
 }
 
-export function getGlobalJisyo(): Jisyo {
+export function getGlobalJisyo(): CompositeJisyo {
     return globalJisyo;
 }
 
@@ -54,6 +54,32 @@ class CompositeJisyo extends CompositeMap<string, Candidate[]> {
         const result = this.maps[0].delete(key);
         saveUserJisyo(this.memento, this.maps[0]);
         return result;
+    }
+
+    /**
+     * Delete a specified candidate from the user dictionary.
+     * @param key 
+     * @param candidate 
+     * @returns 
+     */
+    deleteCandidate(key: string, candidate: Candidate): boolean {
+        if (!this.maps[0].has(key)) {
+            return false;
+        }
+
+        const candidateList = this.maps[0].get(key);
+        if (!candidateList) {
+            return false;
+        }
+
+        const newCandidateList = candidateList.filter((c) => c.word !== candidate.word);
+        if (newCandidateList.length === 0) {
+            this.maps[0].delete(key);
+        } else {
+            this.maps[0].set(key, newCandidateList);
+        }
+        saveUserJisyo(this.memento, this.maps[0]);
+        return true;
     }
 }
 

--- a/src/tests/integration/suite/henkan/deletion-feature.test.ts
+++ b/src/tests/integration/suite/henkan/deletion-feature.test.ts
@@ -1,0 +1,191 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { getGlobalJisyo } from '../../../../jisyo/jisyo';
+import { expect } from 'chai';
+
+suite('候補削除機能において', async () => {
+    const existYomi = 'りですごじわゅょぼざごうにろせふよふ';
+    const existKatakanaYomi = 'リデスゴジワュョボザゴウニロセフヨフ';
+    const candidateWord = 'ほいウ4ホチグハオシルア';
+    const okuriganaAlphabetConsonant = 's';
+    const okuriganaAlphabetVowel = 'a';
+
+    setup('新しい空のエディタを開き、見出し語が登録された状態にする', async () => {
+        await vscode.commands.executeCommand('workbench.action.files.newUntitledFile');
+        await vscode.commands.executeCommand('skk.nop'); // skk 拡張を有効にするための何もしないコマンド呼び出し
+
+        const globalJisyo = getGlobalJisyo();
+        globalJisyo?.delete(existYomi);
+        globalJisyo?.delete(existYomi + okuriganaAlphabetConsonant);
+        globalJisyo?.set(existYomi, [{ word: candidateWord, annotation: undefined }]);
+        globalJisyo?.set(existYomi + okuriganaAlphabetConsonant, [{ word: candidateWord, annotation: undefined }]);
+    });
+
+    teardown('エディタを閉じ、登録された不要な見出し語を削除する', async () => {
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        await vscode.commands.executeCommand('skk.nop'); // skk 拡張を有効にするための何もしないコマンド呼び出し
+
+        const globalJisyo = getGlobalJisyo();
+        globalJisyo?.delete(existYomi);
+        globalJisyo?.delete(existYomi + okuriganaAlphabetConsonant);
+    });
+
+    test('ひらがなで入力した見出し語をインライン変換しているときに X を押すと削除モードになり、Y を押すと候補が削除される', async () => {
+        const document = vscode.window.activeTextEditor?.document;
+        assert.notEqual(document, undefined);
+
+        // ひらがなモードに切り替える
+        await vscode.commands.executeCommand('skk.ctrlJInput');
+
+        // Q キーを入力して、見出し語モードに切り替える
+        await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Q');
+
+        // エディタに、候補が1つだけの見出し語を入力する
+        await vscode.commands.executeCommand('type', { text: existYomi });
+
+        // 新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
+        return new Promise((resolve, reject) => {
+            const disposable1 = vscode.workspace.onDidChangeTextDocument(async e => {
+                disposable1.dispose();
+                const disposable2 = vscode.workspace.onDidChangeTextDocument(async e => {
+                    disposable2.dispose();
+                    try {
+                        const disposable3 = vscode.workspace.onDidChangeTextDocument(async e => {
+                            disposable3.dispose();
+                            try {
+                                // テキストエディタが空になっていることを確認する
+                                expect(document?.getText()).equal('');
+                                // ユーザ辞書から候補が削除されていることを確認する
+                                const candidate = getGlobalJisyo()?.get(existYomi);
+                                expect(candidate).equal(undefined);
+
+                                resolve();
+                            } catch (e) {
+                                reject(e);
+                            }
+                        });
+
+                        // Y を入力して、候補を削除する
+                        vscode.commands.executeCommand('skk.upperAlphabetInput', 'Y');
+                    } catch (e) {
+                        reject(e);
+                    }
+                });
+
+                // X を入力して、候補削除のモードに入る
+                vscode.commands.executeCommand('skk.upperAlphabetInput', 'X');
+            });
+
+            // スペースキーを入力して、見出し語の変換を試みる
+            vscode.commands.executeCommand('skk.spaceInput');
+        });
+    });
+
+    test('カタカナで入力した見出し語をインライン変換しているときに X を押すと削除モードになり、Y を押すと候補が削除される', async () => {
+        const document = vscode.window.activeTextEditor?.document;
+        assert.notEqual(document, undefined);
+
+        // ひらがなモードに切り替える
+        await vscode.commands.executeCommand('skk.ctrlJInput');
+
+        // カタカナモードに切り替える
+        await vscode.commands.executeCommand('skk.lowerAlphabetInput', 'q');
+
+        // Q キーを入力して、見出し語モードに切り替える
+        await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Q');
+
+        // エディタに、候補が1つだけの見出し語をカタカナで入力する
+        await vscode.commands.executeCommand('type', { text: existKatakanaYomi });
+
+        // 新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
+        return new Promise(async (resolve, reject) => {
+            const disposable1 = vscode.workspace.onDidChangeTextDocument(async e => {
+                disposable1.dispose();
+                const disposable2 = vscode.workspace.onDidChangeTextDocument(async e => {
+                    disposable2.dispose();
+                    try {
+                        const disposable3 = vscode.workspace.onDidChangeTextDocument(async e => {
+                            disposable3.dispose();
+                            try {
+                                // テキストエディタが空になっていることを確認する
+                                expect(document?.getText()).equal('');
+                                // ユーザ辞書から候補が削除されていることを確認する
+                                const candidate = getGlobalJisyo()?.get(existYomi);
+                                expect(candidate).equal(undefined);
+
+                                resolve();
+                            } catch (e) {
+                                reject(e);
+                            }
+                        });
+
+                        // Y を入力して、候補を削除する
+                        await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Y');
+                    } catch (e) {
+                        reject(e);
+                    }
+                });
+
+                // X を入力して、候補削除のモードに入る
+                await vscode.commands.executeCommand('skk.upperAlphabetInput', 'X');
+            });
+
+            // スペースキーを入力して、見出し語の変換を試みる
+            await vscode.commands.executeCommand('skk.spaceInput');
+        });
+    });
+
+    test('送りありの見出し語をインライン変換しているときに X を押すと削除モードになり、Y を押すと候補が削除される', async () => {
+        const document = vscode.window.activeTextEditor?.document;
+        assert.notEqual(document, undefined);
+
+        // ひらがなモードに切り替える
+        await vscode.commands.executeCommand('skk.ctrlJInput');
+
+        // Q キーを入力して、見出し語モードに切り替える
+        await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Q');
+
+        // エディタに、候補が1つだけの見出し語を入力する
+        await vscode.commands.executeCommand('type', { text: existYomi });
+
+        // 送りがなの子音を入力する
+        await vscode.commands.executeCommand('skk.upperAlphabetInput', okuriganaAlphabetConsonant.toUpperCase());
+
+        // 新しいエディタが開かれ、内容が辞書登録の初期コンテンツであることを確認する
+        return new Promise(async (resolve, reject) => {
+            const disposable1 = vscode.workspace.onDidChangeTextDocument(async e => {
+                disposable1.dispose();
+                const disposable2 = vscode.workspace.onDidChangeTextDocument(async e => {
+                    disposable2.dispose();
+                    try {
+                        const disposable3 = vscode.workspace.onDidChangeTextDocument(async e => {
+                            disposable3.dispose();
+                            try {
+                                // テキストエディタが空になっていることを確認する
+                                expect(document?.getText()).equal('');
+                                // ユーザ辞書から候補が削除されていることを確認する
+                                const candidate = getGlobalJisyo()?.get(existYomi + okuriganaAlphabetConsonant);
+                                expect(candidate).equal(undefined);
+
+                                resolve();
+                            } catch (e) {
+                                reject(e);
+                            }
+                        });
+
+                        // Y を入力して、候補を削除する
+                        await vscode.commands.executeCommand('skk.upperAlphabetInput', 'Y');
+                    } catch (e) {
+                        reject(e);
+                    }
+                });
+
+                // X を入力して、候補削除のモードに入る
+                await vscode.commands.executeCommand('skk.upperAlphabetInput', 'X');
+            });
+
+            // 送りがなの母音を入力して、見出し語の変換を試みる
+            await vscode.commands.executeCommand('skk.lowerAlphabetInput', okuriganaAlphabetVowel);
+        });
+    });
+});


### PR DESCRIPTION
このプルリクエストは、インライン変換モードにおける候補削除の新機能を導入します。変更点には、候補削除のための新しいモードの追加、この機能をサポートするための既存のモードの修正、辞書管理の更新、機能が期待通りに動作することを確認するための新しいテストが含まれます。

主な変更点:

### 新しい削除候補モード
* 辞書から候補を削除するための `CandidateDeletionMode` クラスを追加した。(`src/input-mode/henkan/CandidateDeletionMode.ts`).

### 既存モードの修正
* `InlineHenkanMode` で `X` キーが押されたときに `CandidateDeletionMode` に切り替わるようにした。(`src/input-mode/henkan/InlineHenkanMode.ts`) [[1]](diffhunk://#diff-1bbacbb3bf48ef0e779276a62d5376142f1262289774a305cd85f5f74dc4786aR14-R15) [[2]](diffhunk://#diff-1bbacbb3bf48ef0e779276a62d5376142f1262289774a305cd85f5f74dc4786aR98-R104) [[3]](diffhunk://#diff-1bbacbb3bf48ef0e779276a62d5376142f1262289774a305cd85f5f74dc4786aL105-R125)

### 辞書管理
* ユーザー辞書からの候補削除をサポートするため、`CompositeJisyo`クラスに `deleteCandidate` メソッドを追加しました。(`src/jisyo/jisyo.ts`)

### テスト
* 削除モードで'Y'が押された時に候補が正しく削除されるように、候補削除機能を検証するためのインテグレーションテストを追加しました。(`src/tests/integration/suite/henkan/deletion-feature.test.ts`)
