### PR TITLE
辞書管理の効率化

### DIFF
--- a/package.json
+++ b/package.json
@@ -503,9 +503,9 @@
           "type": "array",
           "items": "string",
           "default": [
-            "https://github.com/skk-dev/dict/raw/refs/heads/master/SKK-JISYO.L",
-            "https://github.com/skk-dev/dict/raw/refs/heads/master/zipcode/SKK-JISYO.zipcode",
-            "https://github.com/skk-dev/dict/raw/refs/heads/master/SKK-JISYO.fullname"
+            "https://raw.githubusercontent.com/skk-dev/dict/refs/heads/master/SKK-JISYO.L",
+            "https://raw.githubusercontent.com/skk-dev/dict/refs/heads/master/zipcode/SKK-JISYO.zipcode",
+            "https://raw.githubusercontent.com/skk-dev/dict/refs/heads/master/SKK-JISYO.fullname"
           ],
           "description": "List of SKK dictionary URLs to load"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,8 +58,8 @@ function findInputMode(): IInputMode {
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext) {
-	// Initialize jisyo asynchronusly
-	jisyo.init(context.globalState);
+	// Initialize jisyo
+	await jisyo.init(context.globalState, context.globalStorageUri);
 
 	// vscode.window.showInformationMessage("SKK: start");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,10 +168,11 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 		}
 
-		vscode.window.showInformationMessage("SKK: cursor moves");
 		// clear inputMode state
 		findInputMode().reset();
 	});
+
+	vscode.window.showInformationMessage("SKK: initialization completed");
 }
 
 export function insertOrReplaceSelection(str: string): Thenable<boolean> {

--- a/src/input-mode/henkan/RegistrationEditor.ts
+++ b/src/input-mode/henkan/RegistrationEditor.ts
@@ -54,10 +54,8 @@ export async function registerMidashigo(): Promise<void> {
         return;
     }
 
-    const newCandidateList = [{ word, annotation: undefined }, ...getGlobalJisyo().get(yomi) || []];
-    // dedup
-    const deduped = newCandidateList.filter((candidate, index, self) => self.findIndex(c => c.word === candidate.word) === index);
-    getGlobalJisyo().set(yomi, deduped);
+    // ユーザ辞書に登録し、 Memento に保存する
+    getGlobalJisyo().registerCandidate(yomi, {word, annotation: undefined }, true);
 
     // clear all text in the editor
     await editor.edit(editBuilder => {

--- a/src/jisyo/entry.ts
+++ b/src/jisyo/entry.ts
@@ -34,8 +34,7 @@ export class Entry {
         }
 
         // Register reordered candidate list to the jisyo.
-        const newCandidateList = [this.rawCandidateList[index]].concat(this.rawCandidateList.filter((_, i) => i !== index));
-        getGlobalJisyo().set(this.midashigo, newCandidateList);
+        getGlobalJisyo().registerCandidate(this.midashigo, this.rawCandidateList[index], true);
     }
 
     getRawCandidateList(): ReadonlyArray<Candidate> {

--- a/src/jisyo/jisyo.ts
+++ b/src/jisyo/jisyo.ts
@@ -155,8 +155,8 @@ function loadOrInitUserJisyo(memento: vscode.Memento): Jisyo {
     return new Map();
 }
 
-async function loadAllSystemJisyos(memento: vscode.Memento, globalStorageUri: vscode.Uri, jisyoUrls: string[]): Promise<Jisyo[]> {
-    const cacheUri = vscode.Uri.joinPath(globalStorageUri, ...CACHE_DIRECTORY);
+async function loadAllSystemJisyos(memento: vscode.Memento, storageUri: vscode.Uri, jisyoUrls: string[]): Promise<Jisyo[]> {
+    const cacheUri = vscode.Uri.joinPath(storageUri, ...CACHE_DIRECTORY);
 
     // Ensure cache directory exists
     const fs = vscode.workspace.fs;
@@ -166,7 +166,7 @@ async function loadAllSystemJisyos(memento: vscode.Memento, globalStorageUri: vs
     } catch (e) {
         for (let i = 0; i <= CACHE_DIRECTORY.length; i++) {
             const slice = CACHE_DIRECTORY.slice(0, i);
-            const dir = vscode.Uri.joinPath(globalStorageUri, ...slice);
+            const dir = vscode.Uri.joinPath(storageUri, ...slice);
             try {
                 await fs.createDirectory(dir);
             } catch (e) {
@@ -243,17 +243,6 @@ async function loadAllSystemJisyos(memento: vscode.Memento, globalStorageUri: vs
 
     return Promise.all(promises);
 }
-
-/*
-async function fetchAndDecodeDictionary(url: string): Promise<Jisyo> {
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    const rawJisyo = Buffer.from(await response.arrayBuffer());
-    return rawSKKJisyoToJisyo(rawJisyo);
-}
-*/
 
 function rawSKKJisyoToJisyo(rawLines: Buffer): Jisyo {
     const jisyo: Jisyo = new Map();

--- a/src/jisyo/jisyo.ts
+++ b/src/jisyo/jisyo.ts
@@ -1,20 +1,37 @@
-import { Uri } from "vscode";
 import * as vscode from 'vscode';
+import * as path from 'path';
+import { brotliCompress, brotliDecompress } from 'zlib';
+import { promisify } from 'util';
 import { Candidate } from "./candidate";
 import { CompositeMap } from "../lib/composite-map";
 
-type Jisyo = Map<string, Candidate[]>;
+const compress = promisify(brotliCompress);
+const decompress = promisify(brotliDecompress);
 
-const userJisyoKey = "skk.user-jisyo";
+type Jisyo = Map<string, Candidate[]>;
+type CacheMetadata = { expiry: number };
+
+const USER_JISYO_KEY = "skk.user-jisyo";
+const CACHE_EXPIRY_DAYS = 30;
+const CACHE_DIRECTORY = ["cache", "jisyo"];
 
 var globalJisyo: CompositeJisyo;
 
-export async function init(memento: vscode.Memento): Promise<void> {
+export async function init(memento: vscode.Memento, storageUri: vscode.Uri): Promise<void> {
     const cfg = vscode.workspace.getConfiguration("skk");
     const dictUrls = cfg.get<string[]>("dictUrls", ["https://raw.githubusercontent.com/skk-dev/dict/master/SKK-JISYO.L"]);
-    const systemJisyos = await loadAllSystemJisyos(memento, dictUrls);
+    const systemJisyos = await loadAllSystemJisyos(memento, storageUri, dictUrls);
     const userJisyo = loadOrInitUserJisyo(memento);
     globalJisyo = new CompositeJisyo([userJisyo, ...systemJisyos], memento);
+    cleanUpOldMementoKeys(memento);
+}
+
+// Remove old memento keys such like skk.jisyoCache and skk.jisyoCacheExpiries
+async function cleanUpOldMementoKeys(memento: vscode.Memento) {
+    const activeMementoKeys = [USER_JISYO_KEY];
+    memento.keys().filter((key) => !activeMementoKeys.includes(key)).forEach((key) => {
+        memento.update(key, undefined);
+    });
 }
 
 export function getGlobalJisyo(): CompositeJisyo {
@@ -124,13 +141,13 @@ class CompositeJisyo extends CompositeMap<string, Candidate[]> {
      */
     async saveUserJisyo(): Promise<void> {
         vscode.window.showInformationMessage("SKK: Saving user dictionary...");
-        return this.memento.update(userJisyoKey, Object.fromEntries(this.maps[0]));
+        return this.memento.update(USER_JISYO_KEY, Object.fromEntries(this.maps[0]));
     }
 }
 
 function loadOrInitUserJisyo(memento: vscode.Memento): Jisyo {
     // check if local cache is available
-    const cache = memento.get<Object>(userJisyoKey);
+    const cache = memento.get<Object>(USER_JISYO_KEY);
     if (cache) {
         return new Map(Object.entries(cache));
     }
@@ -138,39 +155,96 @@ function loadOrInitUserJisyo(memento: vscode.Memento): Jisyo {
     return new Map();
 }
 
-async function loadAllSystemJisyos(memento: vscode.Memento, urls: string[]): Promise<Jisyo[]> {
-    const savedCache = memento.get<Record<string, object>>("skk.jisyoCache") || {};
-    const savedExpiries = memento.get<Record<string, number>>("skk.jisyoCacheExpiries") || {};
-    const now = Date.now();
+async function loadAllSystemJisyos(memento: vscode.Memento, globalStorageUri: vscode.Uri, jisyoUrls: string[]): Promise<Jisyo[]> {
+    const cacheUri = vscode.Uri.joinPath(globalStorageUri, ...CACHE_DIRECTORY);
 
-    // Expire old or unused caches from savedCache and savedExpiries to prevent memory leak
-    for (const url in savedExpiries) {
-        if (savedExpiries[url] < now || !urls.includes(url)) {
-            delete savedCache[url];
-            delete savedExpiries[url];
+    // Ensure cache directory exists
+    const fs = vscode.workspace.fs;
+    // check if cache directory exists
+    try {
+        await fs.stat(cacheUri);
+    } catch (e) {
+        for (let i = 0; i <= CACHE_DIRECTORY.length; i++) {
+            const slice = CACHE_DIRECTORY.slice(0, i);
+            const dir = vscode.Uri.joinPath(globalStorageUri, ...slice);
+            try {
+                await fs.createDirectory(dir);
+            } catch (e) {
+                // Directory might already exist, that's fine
+            }
         }
     }
-    // the remaining caches are valid
 
-    const promises = urls.map(async (url) => {
-        const cached = savedCache[url];
-        if (cached) {
-            return new Map(Object.entries(cached));
+    // Delete unused cache files, which are not in the urls list
+    const cacheFiles = await fs.readDirectory(cacheUri);
+    cacheFiles.forEach(async ([file, type]) => {
+        if (type === vscode.FileType.File) {
+            const cacheFileName = path.basename(file);
+            const acceptableSuffixes = [".dict.br", ".meta.json"];
+
+            // remove file if file name does not match *.dict.br or *.meta.json
+            if (!acceptableSuffixes.some(ext => cacheFileName.endsWith(ext))) {
+                await fs.delete(vscode.Uri.joinPath(cacheUri, file));
+                return;
+            }
+
+            const cacheKey = acceptableSuffixes.reduce((key, ext) => key.replace(ext, ''), cacheFileName);
+            const url = Buffer.from(cacheKey, 'base64url').toString();
+            if (!jisyoUrls.includes(url)) {
+                await fs.delete(vscode.Uri.joinPath(cacheUri, file));
+            }
         }
-
-        // Cache not found, fetch from the internet
-        const jisyo = await fetchAndDecodeDictionary(url);
-        savedCache[url] = Object.fromEntries(jisyo);
-        savedExpiries[url] = now + 1000 * 60 * 60 * 24 * 30; // 30 days
-        return jisyo;
     });
 
-    const results = await Promise.all(promises);
-    memento.update("skk.jisyoCache", savedCache); // execute asynchronously
-    memento.update("skk.jisyoCacheExpiries", savedExpiries); // execute asynchronously
-    return results;
+    const promises = jisyoUrls.map(async (url) => {
+        const cacheFileName = Buffer.from(url).toString('base64url');
+        const cachePath = vscode.Uri.joinPath(cacheUri, `${cacheFileName}.dict.br`);
+        const metadataPath = vscode.Uri.joinPath(cacheUri, `${cacheFileName}.meta.json`);
+
+        try {
+            // Try to read metadata
+            const metadataBytes = await fs.readFile(metadataPath);
+            const metadata: CacheMetadata = JSON.parse(new TextDecoder().decode(metadataBytes));
+
+            // Check if cache is still valid
+            if (metadata.expiry > Date.now()) {
+                // Read and decompress cached dictionary
+                const compressedData = await fs.readFile(cachePath);
+                const rawJisyo = await decompress(compressedData);
+                return rawSKKJisyoToJisyo(rawJisyo);
+            }
+
+            // Delete expired cache files
+            await fs.delete(cachePath);
+            await fs.delete(metadataPath);
+        } catch (e) {
+            // If any error occurs (file not found, invalid format, etc.), we'll fetch fresh data
+        }
+
+        // Cache not found or expired, fetch from the internet
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const rawJisyo = Buffer.from(await response.arrayBuffer());
+
+        // Save the compressed dictionary and metadata
+        const compressedData = await compress(rawJisyo);
+        const metadata: CacheMetadata = {
+            expiry: Date.now() + CACHE_EXPIRY_DAYS * (1000 * 60 * 60 * 24) // in milliseconds 
+        };
+
+        // Write files asynchronously - don't await as we don't need to block on this
+        fs.writeFile(cachePath, compressedData);
+        fs.writeFile(metadataPath, Buffer.from(JSON.stringify(metadata)));
+
+        return rawSKKJisyoToJisyo(rawJisyo);
+    });
+
+    return Promise.all(promises);
 }
 
+/*
 async function fetchAndDecodeDictionary(url: string): Promise<Jisyo> {
     const response = await fetch(url);
     if (!response.ok) {
@@ -179,6 +253,7 @@ async function fetchAndDecodeDictionary(url: string): Promise<Jisyo> {
     const rawJisyo = Buffer.from(await response.arrayBuffer());
     return rawSKKJisyoToJisyo(rawJisyo);
 }
+*/
 
 function rawSKKJisyoToJisyo(rawLines: Buffer): Jisyo {
     const jisyo: Jisyo = new Map();


### PR DESCRIPTION
このプルリクエストには、拡張機能内のSKK辞書とユーザー辞書の初期化および管理を改善するためのいくつかの変更が含まれています。最も重要な変更点は、`package.json`のURLの更新、初期化プロセスの強化、候補登録のリファクタリング、およびシステム辞書のキャッシュの実装です。

### 初期化と設定:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L506-R508): SKK辞書のURLを`github.com`から`raw.githubusercontent.com`に更新し、ファイルへの直接アクセスを確保しました。
* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L61-R62): `activate`関数を修正し、`jisyo.init`メソッドを待機するようにし、初期化完了を示すメッセージを追加しました。[[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L61-R62) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L171-R175)

### 候補登録と管理:

* [`src/input-mode/henkan/RegistrationEditor.ts`](diffhunk://#diff-1231946c87e2188c8667b2cff4480438d97b378e9f3320642c03513ce8b65eb2L57-R58): 候補登録をリファクタリングし、重複排除とMementoへの保存のために`registerCandidate`メソッドを使用するようにしました。
* [`src/jisyo/entry.ts`](diffhunk://#diff-f099bd82d49100526cebd4a3accf4d53332e9a110a0cc2a419ddb47b724fbd64L37-R37): 候補リストの登録を`registerCandidate`メソッドを使用するように更新し、一貫性を確保しました。

### キャッシュとパフォーマンス:
* [`src/jisyo/jisyo.ts`](diffhunk://#diff-bd7aa7639e5fe35c4a438d1cecd39740f50a0edca472445eb62948a6ec565a53L1-R34): Brotli圧縮を使用してシステム辞書のキャッシュを実装し、キャッシュの有効期限を処理するメソッドを追加し、古いMementoキーをクリーンアップしました。[[1]](diffhunk://#diff-bd7aa7639e5fe35c4a438d1cecd39740f50a0edca472445eb62948a6ec565a53L1-R34) [[2]](diffhunk://#diff-bd7aa7639e5fe35c4a438d1cecd39740f50a0edca472445eb62948a6ec565a53L40-R81) [[3]](diffhunk://#diff-bd7aa7639e5fe35c4a438d1cecd39740f50a0edca472445eb62948a6ec565a53L55-R93) [[4]](diffhunk://#diff-bd7aa7639e5fe35c4a438d1cecd39740f50a0edca472445eb62948a6ec565a53L81-R247) [[5]](diffhunk://#diff-bd7aa7639e5fe35c4a438d1cecd39740f50a0edca472445eb62948a6ec565a53R256) [[6]](diffhunk://#diff-bd7aa7639e5fe35c4a438d1cecd39740f50a0edca472445eb62948a6ec565a53R293-R296)

システム辞書のキャッシュを Memento から分離したことにより、キャッシュ以外のMementoの取得や更新も高速化されたため、拡張機能全体のパフォーマンスが改善しました。