### PR TITLE
Fix punctuation handling on henkan

### DIFF
--- a/src/editor/IEditor.ts
+++ b/src/editor/IEditor.ts
@@ -54,7 +54,7 @@ export interface IEditor {
     fixateMidashigo(): PromiseLike<boolean>;
 
     // Candidate management
-    showCandidate(candidate: Candidate | undefined, suffix: string): PromiseLike<boolean | void>;
+    showCandidate(candidate: Candidate | undefined, okuri: string, suffix: string): PromiseLike<boolean | void>;
     showCandidateList(candidateList: Candidate[], alphabetList: string[]): void;
     hideCandidateList(): void;
     fixateCandidate(candStr: string | undefined): PromiseLike<boolean>;

--- a/src/input-mode/henkan/AbbrevMode.ts
+++ b/src/input-mode/henkan/AbbrevMode.ts
@@ -14,7 +14,7 @@ export class AbbrevMode extends AbstractMidashigoMode {
         context.insertStringAndShowRemaining(insertStr, "", false);
     }
 
-    private async henkan(context: AbstractKanaMode, optionalSuffix?: string): Promise<void> {
+    private async henkan(context: AbstractKanaMode): Promise<void> {
         const midashigo = this.editor.extractMidashigo();
         if (!midashigo || midashigo.length === 0) {
             context.setHenkanMode(KakuteiMode.create(context, this.editor));
@@ -26,7 +26,7 @@ export class AbbrevMode extends AbstractMidashigoMode {
             context.showErrorMessage("変換できません");
             return;
         }
-        context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, "", jisyoCandidates, optionalSuffix));
+        context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, "", jisyoCandidates, "", ""));
     }
 
     async onLowerAlphabet(context: AbstractKanaMode, key: string): Promise<void> {
@@ -54,7 +54,7 @@ export class AbbrevMode extends AbstractMidashigoMode {
     }
 
     async onSpace(context: AbstractKanaMode): Promise<void> {
-        this.henkan(context, "");
+        this.henkan(context);
     }
 
     async onEnter(context: AbstractKanaMode): Promise<void> {

--- a/src/input-mode/henkan/CandidateDeletionMode.ts
+++ b/src/input-mode/henkan/CandidateDeletionMode.ts
@@ -19,8 +19,8 @@ export class CandidateDeletionMode extends AbstractHenkanMode {
         this.showInlineDialog(context, this.midashigo, this.candidate);
     }
 
-    showInlineDialog(context: AbstractKanaMode, midashigo: string, candidate: Candidate) {
-        this.editor.showCandidate(undefined, `Really delete \"${midashigo} /${candidate.word}/\"? (Y/N)`);
+    private async showInlineDialog(context: AbstractKanaMode, midashigo: string, candidate: Candidate): Promise<void> {
+        await this.editor.showCandidate(undefined, `Really delete \"${midashigo} /${candidate.word}/\"? (Y/N)`, '');
     }
 
     async onLowerAlphabet(context: AbstractKanaMode, key: string): Promise<void> {
@@ -30,17 +30,16 @@ export class CandidateDeletionMode extends AbstractHenkanMode {
         throw new Error("Type Y or N");
     }
 
-    clearInlineDialogAndReturnToKakuteiMode(context: AbstractKanaMode) {
+    private async clearInlineDialogAndReturnToKakuteiMode(context: AbstractKanaMode) {
         context.setHenkanMode(KakuteiMode.create(context, this.editor));
-        this.editor.clearCandidate().then(() => {
-            context.insertStringAndShowRemaining("", "", false);
-        });
+        await this.editor.clearCandidate();
+        await context.insertStringAndShowRemaining("", "", false);
     }
 
     async onUpperAlphabet(context: AbstractKanaMode, key: string): Promise<void> {
         if (key === "Y") {
             await this.editor.getJisyoProvider().deleteCandidate(this.midashigo, this.candidate);
-            this.clearInlineDialogAndReturnToKakuteiMode(context);
+            await this.clearInlineDialogAndReturnToKakuteiMode(context);
             return;
         }
 

--- a/src/input-mode/henkan/InlineHenkanMode.ts
+++ b/src/input-mode/henkan/InlineHenkanMode.ts
@@ -17,20 +17,22 @@ export class InlineHenkanMode extends AbstractHenkanMode {
     private readonly jisyoEntry: Entry;
     private candidateIndex: number = 0;
     private readonly suffix: string;
+    private readonly okuri: string;
 
-    constructor(context: AbstractKanaMode, editor: IEditor, prevMode: AbstractMidashigoMode, origMidashigo: string, okuriAlphabet: string, jisyoEntry: Entry, optionalSuffix?: string) {
+    constructor(context: AbstractKanaMode, editor: IEditor, prevMode: AbstractMidashigoMode, origMidashigo: string, okuriAlphabet: string, jisyoEntry: Entry, okuri: string, optionalSuffix?: string) {
         super("▼", editor);
         this.prevMode = prevMode;
         this.origMidashigo = origMidashigo;
         this.okuriAlphabet = okuriAlphabet;
         this.jisyoEntry = jisyoEntry;
+        this.okuri = okuri;
         this.suffix = optionalSuffix || "";
 
         this.showCandidate(context);
     }
 
     showCandidate(context: AbstractKanaMode) {
-        this.editor.showCandidate(this.jisyoEntry.getCandidateList()[this.candidateIndex], this.suffix);
+        this.editor.showCandidate(this.jisyoEntry.getCandidateList()[this.candidateIndex], this.okuri, this.suffix);
     }
 
     /**
@@ -43,7 +45,7 @@ export class InlineHenkanMode extends AbstractHenkanMode {
         if (!rval) {
             return false;
         }
-        await context.insertStringAndShowRemaining(this.suffix, "", false);
+        await context.insertStringAndShowRemaining(this.okuri + this.suffix, "", false);
         return true;
     }
 
@@ -147,7 +149,7 @@ export class InlineHenkanMode extends AbstractHenkanMode {
 
         const MAX_INLINE_CANDIDATES = 3;
         if (this.candidateIndex + 1 >= MAX_INLINE_CANDIDATES) {
-            context.setHenkanMode(new MenuHenkanMode(context, this.editor, this, this.jisyoEntry, this.candidateIndex + 1, this.suffix));
+            context.setHenkanMode(new MenuHenkanMode(context, this.editor, this, this.jisyoEntry, this.candidateIndex + 1, this.okuri, this.suffix));
             return;
         }
 

--- a/src/input-mode/henkan/MenuHenkanMode.ts
+++ b/src/input-mode/henkan/MenuHenkanMode.ts
@@ -10,20 +10,22 @@ export class MenuHenkanMode extends AbstractHenkanMode {
     private readonly jisyoEntry: Entry;
     private readonly candidateIndexStart: number;
     private candidateIndex: number;
+    private readonly okuri: string;
     private readonly suffix: string;
 
     private readonly selectionKeys = ['a', 's', 'd', 'f', 'j', 'k', 'l'];
 
     constructor(context: AbstractKanaMode, editor: IEditor, prevMode: InlineHenkanMode, jisyoEntry: Entry,
-        candidateIndex: number, suffix: string) {
+        candidateIndex: number, okuri: string, suffix: string) {
         super("Select", editor);
         this.prevMode = prevMode;
         this.jisyoEntry = jisyoEntry;
         this.candidateIndexStart = candidateIndex;
         this.candidateIndex = candidateIndex;
+        this.okuri = okuri;
         this.suffix = suffix;
 
-        this.editor.showCandidate(undefined, this.suffix);
+        this.editor.showCandidate(undefined, this.okuri, this.suffix);
         this.showCandidateList(context);
     }
 
@@ -127,7 +129,7 @@ export class MenuHenkanMode extends AbstractHenkanMode {
     private fixateAndGoKakuteiMode(context: AbstractKanaMode, index: number): PromiseLike<boolean> {
         this.jisyoEntry.onCandidateSelected(this.editor.getJisyoProvider(), index);
         context.setHenkanMode(KakuteiMode.create(context, this.editor));
-        return this.editor.fixateCandidate(this.jisyoEntry.getCandidateList()[index].word + this.suffix);
+        return this.editor.fixateCandidate(this.jisyoEntry.getCandidateList()[index].word + this.okuri + this.suffix);
     }
 
     async onCtrlG(context: AbstractKanaMode): Promise<void> {

--- a/src/input-mode/henkan/MidashigoMode.ts
+++ b/src/input-mode/henkan/MidashigoMode.ts
@@ -55,7 +55,7 @@ export class MidashigoMode extends AbstractMidashigoMode {
 
         const okuriAlphabet = okuri.length > 0 ? (lookupOkuriAlphabet(okuri) || "") : "";
         // TODO: optionalTrailingStr をInlineHenkanMode に渡す
-        context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, okuriAlphabet, jisyoEntry, okuri));
+        context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, okuriAlphabet, jisyoEntry, okuri, optionalTrailingStr));
     }
 
     async onLowerAlphabet(context: AbstractKanaMode, key: string): Promise<void> {

--- a/src/tests/unit/input-mode/henkan/MenuHenkanMode.test.ts
+++ b/src/tests/unit/input-mode/henkan/MenuHenkanMode.test.ts
@@ -35,7 +35,7 @@ describe('MenuHenkanMode', () => {
             entry = new Entry('test', candidates, '');
             const midashigoMode = new MidashigoMode(context, mockEditor);
             prevMode = new InlineHenkanMode(context, mockEditor, midashigoMode, 'み', 'み', entry, '');
-            menuHenkanMode = new MenuHenkanMode(context, mockEditor, prevMode, entry, 0, '');
+            menuHenkanMode = new MenuHenkanMode(context, mockEditor, prevMode, entry, 0, '', '');
         });
 
         it('should show candidate list with selection keys', async () => {
@@ -76,7 +76,7 @@ describe('MenuHenkanMode', () => {
             entry = new Entry('test', candidates, '');
             const midashigoMode = new MidashigoMode(context, mockEditor);
             prevMode = new InlineHenkanMode(context, mockEditor, midashigoMode, 'み', 'み', entry, '');
-            menuHenkanMode = new MenuHenkanMode(context, mockEditor, prevMode, entry, 0, '');
+            menuHenkanMode = new MenuHenkanMode(context, mockEditor, prevMode, entry, 0, '', '');
             context.setHenkanMode(menuHenkanMode);
             mockEditor.setInputMode(context);
         });
@@ -117,7 +117,7 @@ describe('MenuHenkanMode', () => {
             entry = new Entry('test', candidates, '');
             const midashigoMode = new MidashigoMode(context, mockEditor, 'kanji');
             prevMode = new InlineHenkanMode(context, mockEditor, midashigoMode, 'かんじ', '', entry, '');
-            menuHenkanMode = new MenuHenkanMode(context, mockEditor, prevMode, entry, 0, '');
+            menuHenkanMode = new MenuHenkanMode(context, mockEditor, prevMode, entry, 0, '', '');
         });
 
         it('should return to midashigo mode on Ctrl+G', async () => {
@@ -136,8 +136,8 @@ describe('MenuHenkanMode', () => {
             expect(mockEditor.getLastErrorMessage()).to.contain('not valid here');
         });
 
-        it('should handle suffix in fixation', async () => {
-            const menuHenkanWithSuffix = new MenuHenkanMode(context, mockEditor, prevMode, entry, 0, 'です');
+        it('should handle okuri in fixation', async () => {
+            const menuHenkanWithSuffix = new MenuHenkanMode(context, mockEditor, prevMode, entry, 0, 'です', '');
             await menuHenkanWithSuffix.onLowerAlphabet(context, 'a');
             expect(mockEditor.getFixatedCandidate()).to.equal('候補1です');
         });
@@ -161,7 +161,7 @@ describe('MenuHenkanMode', () => {
             entry = new Entry('test', candidates, '');
             const midashigoMode = new MidashigoMode(context, mockEditor);
             prevMode = new InlineHenkanMode(context, mockEditor, midashigoMode, 'み', 'み', entry, '');
-            menuHenkanMode = new MenuHenkanMode(context, mockEditor, prevMode, entry, 0, '');
+            menuHenkanMode = new MenuHenkanMode(context, mockEditor, prevMode, entry, 0, '', '');
         });
 
         it('should open registration editor on dot', async () => {

--- a/src/tests/unit/input-mode/henkan/MidashigoMode.test.ts
+++ b/src/tests/unit/input-mode/henkan/MidashigoMode.test.ts
@@ -165,7 +165,8 @@ describe('MidashigoMode', () => {
             await midashigoMode.onLowerAlphabet(context, 'a');
             await midashigoMode.onSymbol(context, '.');
             expect(context["henkanMode"].constructor.name).to.equal('InlineHenkanMode');
-            expect(mockEditor.getCurrentText()).to.equal('▼可。');
+            await context.ctrlJInput();
+            expect(mockEditor.getCurrentText()).to.equal('可。', 'punctuation should be inserted after the kanji');
         });
     });
 });


### PR DESCRIPTION
見出し語モードで句読点などの記号を入力したときに、変換中や確定語に記号が失なわれる問題を修正しました。