### PR TITLE
Fix handling of "n" followed by uppercase letters in input modes

### DIFF
--- a/src/lib/skk/input-mode/henkan/KakuteiMode.ts
+++ b/src/lib/skk/input-mode/henkan/KakuteiMode.ts
@@ -38,7 +38,15 @@ export class KakuteiMode extends AbstractHenkanMode {
             return;
         }
 
-        let midashigoMode = new MidashigoMode(context, this.editor, key);
+        if (this.romajiInput.getRemainingRomaji().length > 0) {
+            // 変換できる文字があればそれを挿入する(例: "n" -> "ん")
+            const kana = this.romajiInput.findExactKanaForRomBuffer();
+            if (kana !== undefined) {
+                await context.insertStringAndShowRemaining(kana, "", false);
+                this.romajiInput.reset();
+            }
+        }
+        const midashigoMode = new MidashigoMode(context, this.editor, this.romajiInput.getRemainingRomaji() + key);
         context.setHenkanMode(midashigoMode);
     }
 

--- a/src/lib/skk/input-mode/henkan/MidashigoMode.ts
+++ b/src/lib/skk/input-mode/henkan/MidashigoMode.ts
@@ -116,25 +116,20 @@ export class MidashigoMode extends AbstractMidashigoMode {
 
         this.midashigoMode = MidashigoType.okurigana;
 
+
         // ローマ字の変換を行う。
+        const kanaForRemainedRomaji = this.romajiInput.findExactKanaForRomBuffer();
+        if (kanaForRemainedRomaji !== undefined) {
+            this.romajiInput.reset();
+        }
+
         const kana = this.romajiInput.processInput(key.toLowerCase());
         const remainingRomaji = this.romajiInput.getRemainingRomaji();
-
+        await context.insertStringAndShowRemaining(kanaForRemainedRomaji || "", remainingRomaji, true);
         if (kana.length === 0) {
-            this.editor.showRemainingRomaji(remainingRomaji, true, 0);
             return;
         }
-        // kana.length > 0
-
-        // key の入力によって、元々ローマ字バッファにあった未変換のローマ字が確定された分については、送り仮名ではなく語幹として取り扱う
-        if (remainingRomaji === key.toLowerCase()) {
-            // key がローマ字バッファに残っているのに kana 1文字以上が出力された。
-            // つまり、 kana は key の入力によって確定された未変換のローマ字である。
-            await context.insertStringAndShowRemaining(kana, remainingRomaji, true);
-            return;
-        }
-
-        this.romajiInput.reset();
+        
         await this.henkan(context, kana);
     }
 

--- a/src/lib/skk/input-mode/henkan/MidashigoMode.ts
+++ b/src/lib/skk/input-mode/henkan/MidashigoMode.ts
@@ -116,14 +116,26 @@ export class MidashigoMode extends AbstractMidashigoMode {
 
         this.midashigoMode = MidashigoType.okurigana;
 
-        const okuri = this.romajiInput.processInput(key.toLowerCase());
-        if (okuri.length === 0) {
-            this.editor.showRemainingRomaji(this.romajiInput.getRemainingRomaji(), true, 0);
+        // ローマ字の変換を行う。
+        const kana = this.romajiInput.processInput(key.toLowerCase());
+        const remainingRomaji = this.romajiInput.getRemainingRomaji();
+
+        if (kana.length === 0) {
+            this.editor.showRemainingRomaji(remainingRomaji, true, 0);
+            return;
+        }
+        // kana.length > 0
+
+        // key の入力によって、元々ローマ字バッファにあった未変換のローマ字が確定された分については、送り仮名ではなく語幹として取り扱う
+        if (remainingRomaji === key.toLowerCase()) {
+            // key がローマ字バッファに残っているのに kana 1文字以上が出力された。
+            // つまり、 kana は key の入力によって確定された未変換のローマ字である。
+            await context.insertStringAndShowRemaining(kana, remainingRomaji, true);
             return;
         }
 
         this.romajiInput.reset();
-        await this.henkan(context, okuri);
+        await this.henkan(context, kana);
     }
 
     async onNumber(context: AbstractKanaMode, key: string): Promise<void> {

--- a/test/unit/lib/skk/input-mode/HiraganaMode.test.ts
+++ b/test/unit/lib/skk/input-mode/HiraganaMode.test.ts
@@ -102,7 +102,7 @@ describe('HiraganaMode', () => {
             // 「っ」と未確定の「s」で見出し語モードが開始する
             expect(hiraganaMode["henkanMode"].constructor.name).to.equal('MidashigoMode');
             expect(mockEditor.getCurrentText()).to.equal('▽っ');
-            expect(mockEditor.getAppendedSuffix()).to.equal('s');
+            expect(mockEditor.getRemainingRomaji()).to.equal('s');
         });
 
         it('should handle "n" correctly in KakuteiMode when followed by uppercase vowel', async () => {
@@ -121,8 +121,8 @@ describe('HiraganaMode', () => {
             // 「ん」が捨てられて、「か」で見出し語モードが開始する欠陥があった。
             // 正しくは、「ん」と未確定の「k」で見出し語モードが開始する
             expect(hiraganaMode["henkanMode"].constructor.name).to.equal('MidashigoMode');
-            expect(mockEditor.getCurrentText()).to.equal('▽ん');
-            expect(mockEditor.getAppendedSuffix()).to.equal('k');
+            expect(mockEditor.getCurrentText()).to.equal('ん▽');
+            expect(mockEditor.getRemainingRomaji()).to.equal('k');
         });
 
         it('should handle "n" correctly in KakuteiMode when followed by uppercase N', async () => {
@@ -132,8 +132,8 @@ describe('HiraganaMode', () => {
             // 「ん」が捨てられて、「n」で見出し語モードが開始する欠陥があった。
             // 正しくは、「ん」と未確定の「n」で見出し語モードが開始する
             expect(hiraganaMode["henkanMode"].constructor.name).to.equal('MidashigoMode');
-            expect(mockEditor.getCurrentText()).to.equal('▽');
-            expect(mockEditor.getAppendedSuffix()).to.equal('n');
+            expect(mockEditor.getCurrentText()).to.equal('ん▽');
+            expect(mockEditor.getRemainingRomaji()).to.equal('n');
         });
     });
 });

--- a/test/unit/lib/skk/input-mode/HiraganaMode.test.ts
+++ b/test/unit/lib/skk/input-mode/HiraganaMode.test.ts
@@ -58,7 +58,7 @@ describe('HiraganaMode', () => {
     });
 
     describe('Unfixed n followd by uppercase letter', () => {
-        it('should handle "n" correctly in MidashigoMode when followed by uppercase letter', async () => {
+        it('should handle "n" correctly in MidashigoMode when followed by uppercase consonant', async () => {
             mockEditor.getJisyoProvider().registerCandidate('かn', { word: '兼' });
             mockEditor.getJisyoProvider().registerCandidate('かんs', { word: '関' });
 
@@ -70,7 +70,7 @@ describe('HiraganaMode', () => {
             // "S" を入力（送り仮名モードに切り替わる）
             await hiraganaMode.upperAlphabetInput('S');
 
-            // 「か」が語幹、「ん」が送り仮名とし解釈される欠陥があった。
+            // 「か」が語幹、「ん」が送り仮名として解釈される欠陥があった。
             // 本来はこの時点ではまだ MidashigoMode であり、「かん」が語幹、「s」が入力途中の送り仮名となっている
             expect(hiraganaMode["henkanMode"].constructor.name).to.equal('MidashigoMode');
             expect(mockEditor.getCurrentText()).to.equal('▽かん'); // 「s」はannotationとして表示される
@@ -82,6 +82,23 @@ describe('HiraganaMode', () => {
             expect(mockEditor.getAppendedSuffix()).to.equal('す');
             // 変換が行われていることを確認
             expect(hiraganaMode["henkanMode"].constructor.name).to.equal('InlineHenkanMode');
+        });
+
+        it('should handle "n" correctly in MidashigoMode when followed by uppercase vowel', async () => {
+            mockEditor.getJisyoProvider().registerCandidate('かn', { word: '兼' });
+            mockEditor.getJisyoProvider().registerCandidate('かんe', { word: '缶' });
+
+            // "kan" を入力
+            await hiraganaMode.upperAlphabetInput('K');
+            await hiraganaMode.lowerAlphabetInput('a');
+            await hiraganaMode.lowerAlphabetInput('n');
+            // "E" を入力（送り仮名モードに切り替わる）
+            await hiraganaMode.upperAlphabetInput('E');
+            // 「か」が語幹、「ね」が送り仮名として解釈される欠陥があった。
+            // 本来は「かん」が語幹、「え」が送り仮名として変換が開始される
+            expect(hiraganaMode["henkanMode"].constructor.name).to.equal('InlineHenkanMode');
+            expect(mockEditor.getCurrentText()).to.equal('▼缶'); // 「え」は送り仮名として表示される
+            expect(mockEditor.getAppendedSuffix()).to.equal('え');
         });
 
         it('should handle consonant correctly in KakuteiMode when followed by uppercase vowel', async () => {

--- a/test/unit/lib/skk/input-mode/HiraganaMode.test.ts
+++ b/test/unit/lib/skk/input-mode/HiraganaMode.test.ts
@@ -78,6 +78,7 @@ describe('HiraganaMode', () => {
         await hiraganaMode.lowerAlphabetInput('u');
         
         expect(mockEditor.getCurrentText()).to.equal('▼関'); // 「す」はannotationとして表示される
+        expect(mockEditor.getAppendedSuffix()).to.equal('す');
         // 変換が行われていることを確認
         expect(hiraganaMode["henkanMode"].constructor.name).to.equal('InlineHenkanMode');
     });

--- a/test/unit/lib/skk/input-mode/henkan/MidashigoMode.test.ts
+++ b/test/unit/lib/skk/input-mode/henkan/MidashigoMode.test.ts
@@ -97,7 +97,8 @@ describe('MidashigoMode', () => {
             await midashigoMode.onUpperAlphabet(context, 'K');
             await midashigoMode.onLowerAlphabet(context, 'a');
             expect(context["henkanMode"].constructor.name).to.equal('InlineHenkanMode');
-            expect(mockEditor.getCurrentText()).to.equal('▼書か');
+            expect(mockEditor.getCurrentText()).to.equal('▼書'); // 送りがなは本文として表示されない
+            expect(mockEditor.getAppendedSuffix()).to.equal('か');
         });
 
     });

--- a/test/unit/mocks/MockEditor.ts
+++ b/test/unit/mocks/MockEditor.ts
@@ -369,7 +369,7 @@ export class MockEditor implements IEditor {
         this.appendedSuffix = suffix;
         if (candidate) {
             // 候補を表示する際にカーソル位置も更新
-            const text = '▼' + candidate.word + (suffix || '');
+            const text = '▼' + candidate.word; // suffix はエディタのテキストとしては表示せず、インラインのアノテーションとして表示する
             if (this.midashigoStartPosition) {
                 this.currentText = this.currentText.slice(0, this.midashigoStartPosition.character) +
                     text +


### PR DESCRIPTION
Enhance the handling of the unfixed roman letter "n" when followed by uppercase consonants and vowels in MidashigoMode and KakuteiMode. Update tests to ensure correct behavior in these scenarios. Adjust MockEditor to properly display suffixes as inline annotations.