### PR TITLE
fix(MidashigoMode): reset midashigo mode to gokan after deleting all …

### DIFF
--- a/src/lib/skk/input-mode/henkan/MidashigoMode.ts
+++ b/src/lib/skk/input-mode/henkan/MidashigoMode.ts
@@ -182,6 +182,9 @@ export class MidashigoMode extends AbstractMidashigoMode {
         if (!this.romajiInput.isEmpty()) {
             this.romajiInput.deleteLastChar();
             await context.insertStringAndShowRemaining("", this.romajiInput.getRemainingRomaji(), false);
+            if (this.romajiInput.isEmpty()) {
+                this.midashigoMode = MidashigoType.gokan;
+            }
             return;
         }
 

--- a/test/unit/lib/skk/input-mode/henkan/MidashigoMode.test.ts
+++ b/test/unit/lib/skk/input-mode/henkan/MidashigoMode.test.ts
@@ -171,7 +171,7 @@ describe('MidashigoMode', () => {
         });
     });
 
-    describe('behaviror after deleting okuri-alphabet', () => {
+    describe('behavior after deleting okuri-alphabet', () => {
         let midashigoMode: MidashigoMode;
         let mockEditor: MockEditor;
         let context: AbstractKanaMode;

--- a/test/unit/lib/skk/input-mode/henkan/MidashigoMode.test.ts
+++ b/test/unit/lib/skk/input-mode/henkan/MidashigoMode.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { MidashigoMode } from '../../../../../../src/lib/skk/input-mode/henkan/MidashigoMode';
+import { MidashigoMode, MidashigoType } from '../../../../../../src/lib/skk/input-mode/henkan/MidashigoMode';
 import { MockEditor } from '../../../../mocks/MockEditor';
 import { AbstractKanaMode } from '../../../../../../src/lib/skk/input-mode/AbstractKanaMode';
 import { HiraganaMode } from '../../../../../../src/lib/skk/input-mode/HiraganaMode';
@@ -168,6 +168,34 @@ describe('MidashigoMode', () => {
             expect(context["henkanMode"].constructor.name).to.equal('InlineHenkanMode');
             await context.ctrlJInput();
             expect(mockEditor.getCurrentText()).to.equal('可。', 'punctuation should be inserted after the kanji');
+        });
+    });
+
+    describe('behaviror after deleting okuri-alphabet', () => {
+        let midashigoMode: MidashigoMode;
+        let mockEditor: MockEditor;
+        let context: AbstractKanaMode;
+
+        beforeEach(() => {
+            mockEditor = new MockEditor();
+            context = new HiraganaMode();
+            midashigoMode = new MidashigoMode(context, mockEditor, '');
+            context.setHenkanMode(midashigoMode);
+            mockEditor.setInputMode(context);
+        });
+
+        it('should handle okurigana deletion correctly', async () => {
+            await midashigoMode.onLowerAlphabet(context, 'k');
+            await midashigoMode.onLowerAlphabet(context, 'a');
+            await midashigoMode.onUpperAlphabet(context, 'K');
+
+            expect(midashigoMode["midashigoMode"]).to.equal(MidashigoType.okurigana, 'should be in okurigana mode');
+
+            await midashigoMode.onBackspace(context);
+            
+            expect(midashigoMode["midashigoMode"]).to.equal(MidashigoType.gokan, 'should be in gokan mode');
+            expect(mockEditor.getCurrentText()).to.equal('▽か');
+            expect(mockEditor.getRemainingRomaji()).to.equal('', 'should have no remaining romaji');
         });
     });
 });


### PR DESCRIPTION
This pull request fixes the handling of okurigana removal in the `MidashigoMode` class.
When backspace empties the romaji input, `MidashigoMode` will now switch to `gokan` mode and correctly continue input.
In addition, a test case has been added to verify this behavior.