### PR TITLE
Fix to go back to gokan mode when returning to MidashigoMode from mid…

### DIFF
--- a/src/lib/skk/input-mode/henkan/AbbrevMode.ts
+++ b/src/lib/skk/input-mode/henkan/AbbrevMode.ts
@@ -13,6 +13,10 @@ export class AbbrevMode extends AbstractMidashigoMode {
         context.insertStringAndShowRemaining(insertStr, "", false);
     }
 
+    resetOkuriState(): void {
+        // do nothing
+    }
+
     private async henkan(context: AbstractKanaMode): Promise<void> {
         const midashigo = this.editor.extractMidashigo();
         if (!midashigo || midashigo.length === 0) {

--- a/src/lib/skk/input-mode/henkan/AbstractMidashigoMode.ts
+++ b/src/lib/skk/input-mode/henkan/AbstractMidashigoMode.ts
@@ -1,4 +1,5 @@
 import { AbstractHenkanMode } from "./AbstractHenkanMode";
 
 export abstract class AbstractMidashigoMode extends AbstractHenkanMode {
+    abstract resetOkuriState(): void;
 }

--- a/src/lib/skk/input-mode/henkan/InlineHenkanMode.ts
+++ b/src/lib/skk/input-mode/henkan/InlineHenkanMode.ts
@@ -84,12 +84,9 @@ export class InlineHenkanMode extends AbstractHenkanMode {
 
     async returnToMidashigoMode(context: AbstractKanaMode) {
         context.setHenkanMode(this.prevMode);
-        // recover orijinal midashigo
-        // await this.editor.clearCandidate().then(() => {
-        //     context.insertStringAndShowRemaining("▽" + this.origMidashigo + this.suffix, "", false);
-        // });
+        this.prevMode.resetOkuriState();
         await this.editor.clearCandidate();
-        await context.insertStringAndShowRemaining("▽" + this.origMidashigo + this.suffix, "", false);
+        await context.insertStringAndShowRemaining("▽" + this.origMidashigo + this.okuri + this.suffix, "", false);
     }
 
     async clearMidashigoAndReturnToKakuteiMode(context: AbstractKanaMode) {

--- a/src/lib/skk/input-mode/henkan/MidashigoMode.ts
+++ b/src/lib/skk/input-mode/henkan/MidashigoMode.ts
@@ -27,6 +27,10 @@ export class MidashigoMode extends AbstractMidashigoMode {
         context.insertStringAndShowRemaining(insertStr, this.romajiInput.getRemainingRomaji(), false);
     }
 
+    resetOkuriState(): void {
+        this.midashigoMode = MidashigoType.gokan;
+    }
+
     async findCandidates(midashigo: string, okuri: string): Promise<Entry | undefined> {
         const { key, keyForLookup } = this.createJisyoKey(midashigo, okuri);
         return await this.editor.getJisyoProvider().lookupCandidates(keyForLookup);
@@ -54,7 +58,6 @@ export class MidashigoMode extends AbstractMidashigoMode {
         }
 
         const okuriAlphabet = okuri.length > 0 ? (lookupOkuriAlphabet(okuri) || "") : "";
-        // TODO: optionalTrailingStr をInlineHenkanMode に渡す
         context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, okuriAlphabet, jisyoEntry, okuri, optionalTrailingStr));
     }
 

--- a/test/unit/lib/skk/input-mode/HiraganaMode.test.ts
+++ b/test/unit/lib/skk/input-mode/HiraganaMode.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { HiraganaMode } from '../../../../../src/lib/skk/input-mode/HiraganaMode';
 import { MockEditor } from '../../../mocks/MockEditor';
+import { MidashigoMode, MidashigoType } from '../../../../../src/lib/skk/input-mode/henkan/MidashigoMode';
 
 describe('HiraganaMode', () => {
     let hiraganaMode: HiraganaMode;
@@ -57,7 +58,7 @@ describe('HiraganaMode', () => {
         expect(mockEditor.getCurrentInputMode().constructor.name).to.equal('AsciiMode');
     });
 
-    describe('Unfixed n followd by uppercase letter', () => {
+    describe('Integration test: Unfixed n followd by uppercase letter', () => {
         it('should handle "n" correctly in MidashigoMode when followed by uppercase consonant', async () => {
             mockEditor.getJisyoProvider().registerCandidate('かn', { word: '兼' });
             mockEditor.getJisyoProvider().registerCandidate('かんs', { word: '関' });
@@ -151,6 +152,28 @@ describe('HiraganaMode', () => {
             expect(hiraganaMode["henkanMode"].constructor.name).to.equal('MidashigoMode');
             expect(mockEditor.getCurrentText()).to.equal('ん▽');
             expect(mockEditor.getRemainingRomaji()).to.equal('n');
+        });
+    });
+
+    describe('Integration test: Returning to MidashigoMode from okuri-ari midashigo conversion', () => {
+        it('should be in gokan mode when returning from okuri-ari midashigo conversion', async () => {
+            mockEditor.getJisyoProvider().registerCandidate('あu', { word: '合' });
+
+            // "AU" を入力して InlineHenkanMode に遷移
+            await hiraganaMode.upperAlphabetInput('A');
+            await hiraganaMode.upperAlphabetInput('U');
+
+            expect(hiraganaMode["henkanMode"].constructor.name).to.equal('InlineHenkanMode');
+
+            // x を入力して MidashigoMode に戻る
+            await hiraganaMode.lowerAlphabetInput('x');
+            expect(hiraganaMode["henkanMode"].constructor.name).to.equal('MidashigoMode');
+
+            // DDSKK 互換の振舞いとして、送り仮名は語幹に追加される
+            expect(mockEditor.getCurrentText()).to.equal('▽あう');
+
+            // midashigoMode は gokan でなければならない
+            expect((hiraganaMode["henkanMode"] as MidashigoMode)["midashigoMode"]).to.equal(MidashigoType.gokan, 'should be in gokan mode');
         });
     });
 });

--- a/test/unit/lib/skk/input-mode/HiraganaMode.test.ts
+++ b/test/unit/lib/skk/input-mode/HiraganaMode.test.ts
@@ -58,7 +58,7 @@ describe('HiraganaMode', () => {
         expect(mockEditor.getCurrentInputMode().constructor.name).to.equal('AsciiMode');
     });
 
-    describe('Integration test: Unfixed n followd by uppercase letter', () => {
+    describe('Integration test: Unfixed n followed by uppercase letter', () => {
         it('should handle "n" correctly in MidashigoMode when followed by uppercase consonant', async () => {
             mockEditor.getJisyoProvider().registerCandidate('かn', { word: '兼' });
             mockEditor.getJisyoProvider().registerCandidate('かんs', { word: '関' });


### PR DESCRIPTION
This pull request fixes an inconsistency when returning to `MidashigoMode` from a conversion between okuri and midashigo.

When returning from an entry with okuri, MidashigoMode will be in the gokan input state, and the okuri given at the time of conversion will be appended to the end of gokan.
This behavior is the same as in DDSKK.

A test for this behavior has also been added.
