### PR TITLE
Fix Abbrev mode dictionary registration behavior

### DIFF
--- a/src/lib/skk/input-mode/henkan/AbbrevMode.ts
+++ b/src/lib/skk/input-mode/henkan/AbbrevMode.ts
@@ -26,7 +26,7 @@ export class AbbrevMode extends AbstractMidashigoMode {
 
         const jisyoCandidates = await this.editor.getJisyoProvider().lookupCandidates(midashigo);
         if (jisyoCandidates=== undefined) {
-            context.showErrorMessage("変換できません");
+            await this.editor.openRegistrationEditor(midashigo, "");
             return;
         }
         context.setHenkanMode(new InlineHenkanMode(context, this.editor, this, midashigo, "", jisyoCandidates, "", ""));

--- a/src/lib/skk/input-mode/henkan/InlineHenkanMode.ts
+++ b/src/lib/skk/input-mode/henkan/InlineHenkanMode.ts
@@ -7,8 +7,8 @@ import { AbstractHenkanMode } from "./AbstractHenkanMode";
 import { KakuteiMode } from "./KakuteiMode";
 import { MenuHenkanMode } from "./MenuHenkanMode";
 import { AbstractMidashigoMode } from "./AbstractMidashigoMode";
-import { toHiragana } from 'wanakana';
 import { CandidateDeletionMode } from './CandidateDeletionMode';
+import wanakana = require('wanakana');
 
 export class InlineHenkanMode extends AbstractHenkanMode {
     private readonly prevMode: AbstractMidashigoMode;
@@ -180,7 +180,13 @@ export class InlineHenkanMode extends AbstractHenkanMode {
         await this.returnToMidashigoMode(context);
     }
 
-    getMidashigo() {
-        return toHiragana(this.origMidashigo) + this.okuriAlphabet;
+    /**
+     * 辞書の見出し語に使えない文字を、使える文字に変換する。具体的には、カタカナをひらがなに変換する。
+     * @returns {string} 辞書の見出し語
+     */
+    getMidashigo(): string {
+        return this.origMidashigo.split("").map((char) => {
+            return wanakana.isKatakana(char) ? wanakana.toHiragana(char) : char;
+        }).join("") + this.okuriAlphabet;
     }
 }

--- a/test/unit/lib/skk/input-mode/henkan/AbbrevMode.test.ts
+++ b/test/unit/lib/skk/input-mode/henkan/AbbrevMode.test.ts
@@ -80,6 +80,26 @@ describe('AbbrevMode', async () => {
             abbrevMode.onSpace(context);
             expect(mockEditor.getMidashigo()).to.equal('http');
         });
+
+        it('should registration editor have unconverted romaji yomi', async () => {
+            mockEditor.getJisyoProvider().registerCandidate('a', { word: 'α' });
+            await context.lowerAlphabetInput('a');
+            expect(mockEditor.getMidashigo()).to.equal('a');
+            await context.spaceInput();
+            expect(context["henkanMode"].constructor.name).to.equal('InlineHenkanMode');
+            expect(mockEditor.getCurrentText()).to.equal('▼α');
+            await context.spaceInput();
+            expect(mockEditor.wasRegistrationEditorOpened()).to.be.true;
+            expect(mockEditor.getRegistrationYomi()).to.equal('a', "辞書登録の読みは'a'であるべき");
+        });
+
+        it('should open registration editor on converting unexisting abbrev word', async () => {
+            const unexistingWord = 'ahoskihoiasdfo';
+            context.lowerAlphabetInput(unexistingWord);
+            await context.spaceInput();
+            expect(mockEditor.wasRegistrationEditorOpened()).to.be.true;
+            expect(mockEditor.getRegistrationYomi()).to.equal(unexistingWord, `辞書登録の読みは'${unexistingWord}'であるべき`);
+        });
     });
 
     describe('special input handling', () => {

--- a/test/unit/mocks/MockEditor.ts
+++ b/test/unit/mocks/MockEditor.ts
@@ -22,29 +22,29 @@ function indexOfPositionInString(str: string, pos: IPosition): number | undefine
         if (n === 0) {
             return -1;
         }
-        
+
         let index = -searchStr.length;
-        
+
         for (let count = 0; count < n; count++) {
             index = str.indexOf(searchStr, index + searchStr.length);
             if (index === -1) {
                 return undefined;
             }
         }
-        
+
         return index;
     }
 
     if (pos.line === 0 && pos.character === 0) {
         return 0;
     }
-    
+
     const lastLineEndIndex = positionOfNthOccurence(str, '\n', pos.line);
     if (lastLineEndIndex === undefined) {
         return undefined;
     }
     // check if str[lastLineEndIndex+1 .. lastLineEndIndex+1+pos.character] is valid
-    const strSlice = str.slice(lastLineEndIndex+1, lastLineEndIndex + 1 + pos.character);
+    const strSlice = str.slice(lastLineEndIndex + 1, lastLineEndIndex + 1 + pos.character);
     if (strSlice.length !== pos.character || strSlice.includes('\n')) {
         return undefined;
     }
@@ -150,6 +150,7 @@ export class MockEditor implements IEditor {
     private midashigoStartPosition: IPosition | null = null;
     private appendedSuffix: string = '';
     private jisyoProvider: IJisyoProvider;
+    private registrationYomi: string|undefined = undefined;
 
     constructor() {
         // まずEditorFactoryを初期化
@@ -550,6 +551,11 @@ export class MockEditor implements IEditor {
 
     async openRegistrationEditor(yomi: string): Promise<void> {
         this.wasRegistrationEditorOpened_ = true;
+        this.registrationYomi = yomi;
+    }
+
+    getRegistrationYomi(): string | undefined {
+        return this.registrationYomi;
     }
 
     async registerMidashigo(): Promise<void> {


### PR DESCRIPTION
The changes ensure that when entering the dictionary registration editor from Abbrev mode, the yomi remains as typed instead of being converted to romaji. Additionally, the registration editor now opens correctly when a non-existent candidate is converted in Abbrev mode. Tests have been added to verify these behaviors.

Fixes #52, #53